### PR TITLE
Stylingissue spelregels op plan-indien-pagina als accordeon bovenaan

### DIFF
--- a/lib/modules/section-widgets/public/css/main.less
+++ b/lib/modules/section-widgets/public/css/main.less
@@ -46,6 +46,14 @@
 
 .section {
 
+  .howDoesItWorkButton {
+    outline: 0;
+    background: #dfdfdf;
+    color: black;
+    padding: 15px 20px;
+    text-align: center;
+  }
+
   &.mobileonly {
     .howDoesItWorkButton {
       display: none;
@@ -61,34 +69,28 @@
       }
 
       &.closed {
-
         .row {
           display: none!important
         }
-
         .arrow {
           transform: rotate(0deg);
         }
-
       }
 
       &.open {
-
         .row {
           display: block!important;
         }
-
         .arrow {
           transform: rotate(180deg);
         }
-
       }
     }
   }
 
   &.closed {
 
-    .row {
+    .container {
       display: none
     }
 


### PR DESCRIPTION
Dit lost het stylingprobleem van de spelregels-toggle op zoals beschreven in https://trello.com/c/I6BU4CSb/435-spelregels-op-planindienpagina-weergeven-in-accordeon-bovenaan