### PR TITLE
Fix typo in titleField for list widget

### DIFF
--- a/lib/modules/list-widgets/index.js
+++ b/lib/modules/list-widgets/index.js
@@ -20,7 +20,7 @@ module.exports = {
           name: 'subitems',
           label: 'Subitems',
           type: 'array',
-          titleField: 'subitems',
+          titleField: 'subitem',
           schema: [
             {
               type: 'string',


### PR DESCRIPTION
This fixes a bug where the titles of the subitems would not be shown when editing the subitems in a list widget.