### PR TITLE
Add option create an ordered list from the list-widget

### DIFF
--- a/lib/modules/list-widgets/index.js
+++ b/lib/modules/list-widgets/index.js
@@ -50,6 +50,10 @@ module.exports = {
             {
               label: 'Stripes',
               value: 'uk-list uk-list-striped'
+            },
+            {
+              label: 'Numbers',
+              value: 'uk-list uk-list-numbers'
             }
           ]
         },
@@ -75,6 +79,10 @@ module.exports = {
         {
           label: 'Stripes',
           value: 'uk-list uk-list-striped'
+        },
+        {
+          label: 'Numbers',
+          value: 'uk-list uk-list-numbers'
         }
       ]
     },

--- a/lib/modules/list-widgets/views/widget.html
+++ b/lib/modules/list-widgets/views/widget.html
@@ -2,7 +2,7 @@
   {{data.widget.formattedContainerStyles}}
 </style>
 
-{% if data.widget.listClassName === 'numbers' %}
+{% if data.widget.listClassName === 'uk-list uk-list-numbers' %}
   {% set listType = 'ol' %}
 {% else %}
   {% set listType = 'ul' %}
@@ -12,7 +12,7 @@
   {% for item in data.widget.items %}
   <li>
     {{ item.item | safe }}
-    {% if item.subListClassName === 'numbers' %}
+    {% if item.subListClassName === 'uk-list uk-list-numbers' %}
       {% set subListType = 'ol' %}
     {% else %}
       {% set subListType = 'ul' %}

--- a/lib/modules/list-widgets/views/widget.html
+++ b/lib/modules/list-widgets/views/widget.html
@@ -2,15 +2,27 @@
   {{data.widget.formattedContainerStyles}}
 </style>
 
-<ul id="{{data.widget.containerId}}" class="{{data.widget.listClassName}}">
+{% if data.widget.listClassName === 'numbers' %}
+  {% set listType = 'ol' %}
+{% else %}
+  {% set listType = 'ul' %}
+{% endif %}
+
+<{{listType}} id="{{data.widget.containerId}}" class="{{data.widget.listClassName}}">
   {% for item in data.widget.items %}
   <li>
     {{ item.item | safe }}
-    <ul class="{{item.subListClassName}}">
+    {% if item.subListClassName === 'numbers' %}
+      {% set subListType = 'ol' %}
+    {% else %}
+      {% set subListType = 'ul' %}
+    {% endif %}
+
+    <{{subListType}} class="{{item.subListClassName}}">
       {% for subitem in item.subitems %}
       <li> {{ subitem.subitem | safe }} </li>
       {% endfor %}
-    </ul>
+    </{{subListType}}>
   </li>
   {% endfor %}
-</ul>
+</{{listType}}>


### PR DESCRIPTION
The ordered list will create an `<ol>` instead of a `<ul>`. This also works for sub lists

Related ticket: https://trello.com/c/CNAnVpJq/567-het-type-list-van-de-list-widgets-aan-kunnen-passen-naar-ordered-unordered