### PR TITLE
Allow HTML to be entered into the info bar widget

### DIFF
--- a/lib/modules/info-bar-widgets/views/widget.html
+++ b/lib/modules/info-bar-widgets/views/widget.html
@@ -11,7 +11,7 @@
   "
 >
     <span class="info-block-message">
-      {{data.widget.message}}
+      {{data.widget.message | safe}}
     </span>
     {% if data.widget.removable %}
     <div class="close-button"></div>


### PR DESCRIPTION
This allows the admins to insert links into the info bar for instance

Related ticket: https://trello.com/c/QqifkGHK/585-links-plaatsen-in-info-bar-tekst