### PR TITLE
Only show description in budgeting ideas list when it's not empty

### DIFF
--- a/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
+++ b/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
@@ -140,9 +140,11 @@
 						<div class="intro">
 							{{idea.summary | safe}}
 						</div>
+						{% if idea.description %}
 						<div class="description">
 							{{idea.description | safe}}
 						</div>
+						{% endif %}
 						{% if data.isAdmin %}
 							<div class="description"><a href="{{data.global.editIdeaUrl}}?ideaId={{idea.id}}" target="_blank">Bewerk dit plan</a></div>
 						{% endif %}


### PR DESCRIPTION
Related ticket: https://trello.com/c/JGqWDocB/600-bij-het-idee%C3%ABnoverzicht-tijdens-fase-2-budgeteren-alleen-de-beschrijving-tonen-indien-deze-niet-leeg-is