### PR TITLE
Hide the seperator between plan theme and area in the begroten overview

### DIFF
--- a/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
+++ b/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
@@ -28,7 +28,7 @@
 				<h3 class="title">{{idea.title}}</h3>
 				{% if idea.extraData %}
 				<div class="thema-en-gebied underscription">
-					<span class="thema theme-{{idea.id}}">{{idea.extraData.theme}}</span> | <span class="gebied area-{{idea.id}}">{{idea.extraData.area}}</span>
+					<span class="thema theme-{{idea.id}}">{{idea.extraData.theme}}</span>{% if idea.extraData.area %} | <span class="gebied area-{{idea.id}}">{{idea.extraData.area}}</span>{% endif %}
 				</div>
 				{% endif %}
 			</div>


### PR DESCRIPTION
Related ticket: https://trello.com/c/XgP4Okgs/602-bij-het-budgeteren-fase-2-moet-het-scheidingsteken-tussen-thema-en-gebied-alleen-tonen-als-de-locatie-ingevuld-is