### PR TITLE
Add target option to the right-side button in the header widget

### DIFF
--- a/lib/modules/header-widgets/index.js
+++ b/lib/modules/header-widgets/index.js
@@ -116,6 +116,7 @@ module.exports = {
             name: 'targetBlank',
             type: 'boolean',
             label: 'Open in new window',
+            def: false
         }
     ],
 

--- a/lib/modules/header-widgets/index.js
+++ b/lib/modules/header-widgets/index.js
@@ -112,6 +112,11 @@ module.exports = {
             trash: true,
             svgImages: true
         },
+        {
+            name: 'targetBlank',
+            type: 'boolean',
+            label: 'Open in new window',
+        }
     ],
 
     construct: function(self, options) {

--- a/lib/modules/header-widgets/views/widget.html
+++ b/lib/modules/header-widgets/views/widget.html
@@ -38,7 +38,7 @@
                         </span>
                     </a>
                     {% if data.widget.showBtn %}
-                    <a href="{{data.widget.btnUrl}}" class="link-box scroll-link margin-bottom-sm button-with-icon" style="">
+                    <a href="{{data.widget.btnUrl}}" class="link-box scroll-link margin-bottom-sm button-with-icon" style=""   {% if data.widget.targetBlank %} target="_blank" {% endif %}>
 
                         <img src="{{apos.attachments.url(data.widget.btnIcon)}}">
 


### PR DESCRIPTION
Related ticket: https://trello.com/c/TErFXPBB/605-knop-in-rechterkolom-van-de-header-moet-een-aanpasbare-target-hebben