### PR TITLE
Add newsletter subscription functionality after submitting a budget vote

### DIFF
--- a/lib/modules/begroot-widgets/index.js
+++ b/lib/modules/begroot-widgets/index.js
@@ -53,7 +53,6 @@ module.exports = {
           label: 'Count',
           value: 'count',
           showFields: [ 'maxIdeas', 'minIdeas' ]
-
         },
       ]
     },
@@ -139,6 +138,29 @@ module.exports = {
       type: 'string',
       textarea: true,
       def: 'Bedankt voor het stemmen! De stemperiode loopt van 9 september t/m 6 oktober 2019. Wil je weten welke plannen het vaakst zijn gekozen en uitgevoerd worden? De uitslag wordt op 15 oktober 2019 gepubliceerd op centrumbegroot.amsterdam.nl.'
+    },
+    {
+      name:    'showNewsletterButton',
+      label:   'Show newsletter button after voting?',
+      type:    'select',
+      choices: [
+        {
+          label: 'No',
+          value: 'no'
+        },
+        {
+          label:      'Yes',
+          value:      'yes',
+          showFields: ['newsletterButtonText']
+        }
+      ],
+      def:     'no'
+    },
+    {
+      name: 'newsletterButtonText',
+      label: 'Text on the newsletter button',
+      type: 'string',
+      def: 'Blijf op de hoogte'
     },
   ],
   construct: function(self, options) {

--- a/lib/modules/begroot-widgets/index.js
+++ b/lib/modules/begroot-widgets/index.js
@@ -159,8 +159,7 @@ module.exports = {
     {
       name: 'newsletterButtonText',
       label: 'Text on the newsletter button',
-      type: 'string',
-      def: 'Blijf op de hoogte'
+      type: 'string'
     },
   ],
   construct: function(self, options) {

--- a/lib/modules/begroot-widgets/views/phase-voting/budgeting.html
+++ b/lib/modules/begroot-widgets/views/phase-voting/budgeting.html
@@ -160,10 +160,6 @@
 								</a>
 								<div class="mobile-accordion-body">
 									{{data.widget.step_1_intro}}
-
-
-
-
 								</div>
 							</div>
 							<br class="visible-xs" />
@@ -265,6 +261,11 @@
 								<h4>Gelukt, je hebt gestemd!</h4>
 								<br/>
 								{{data.widget.thankyou_message}}
+								{% if data.widget.showNewsletterButton and data.widget.showNewsletterButton == 'yes' %}
+								<br />
+								<br />
+								<a href="#newsletter" class="outlined-button">{{ data.widget.newsletterButtonText }}</a>
+								{% endif %}
 							</div>
 						</div>
 					</div>

--- a/lib/modules/begroot-widgets/views/phase-voting/budgeting.html
+++ b/lib/modules/begroot-widgets/views/phase-voting/budgeting.html
@@ -264,7 +264,7 @@
 								{% if data.widget.showNewsletterButton and data.widget.showNewsletterButton == 'yes' %}
 								<br />
 								<br />
-								<a href="#newsletter" class="outlined-button">{{ data.widget.newsletterButtonText }}</a>
+								<a href="#newsletter" class="outlined-button">{{ data.widget.newsletterButtonText or __('Sign up for the newsletter') }}</a>
 								{% endif %}
 							</div>
 						</div>

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -417,9 +417,8 @@
 	"Revert": "Revert",
 	"Page header": "Page header",
 	"Edit Page header": "Edit Page header",
-	"First name": "First name",
-	"Email": "Email",
-	"Sign up": "Sign up",
+	"Email": "E-mail",
+	"Sign up": "Inschrijven",
 	"Subitems": "Subitems",
 	"Subitem": "Subitem",
 	"Select appearance modus for subitems": "Select appearance modus for subitems",
@@ -443,8 +442,8 @@
 	"Ranking": "Ranking",
 	"Loading...": "Laden...",
 	"First name": "Voornaam",
-	"Email": "E-mail",
-	"Sign up": "Inschrijven",
 	"Highest amount": "Hoogste bedrag",
-	"Lowest amount": "Laagste bedrag"
+	"Lowest amount": "Laagste bedrag",
+	"Mijn account": "Mijn account",
+	"Iframe": "Iframe"
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -444,7 +444,5 @@
 	"First name": "Voornaam",
 	"Highest amount": "Hoogste bedrag",
 	"Lowest amount": "Laagste bedrag",
-	"Mijn account": "Mijn account",
-	"Iframe": "Iframe",
 	"Sign up for the newsletter": "Schrijf je in voor de nieuwsbrief"
 }

--- a/locales/nl.json
+++ b/locales/nl.json
@@ -445,5 +445,6 @@
 	"Highest amount": "Hoogste bedrag",
 	"Lowest amount": "Laagste bedrag",
 	"Mijn account": "Mijn account",
-	"Iframe": "Iframe"
+	"Iframe": "Iframe",
+	"Sign up for the newsletter": "Schrijf je in voor de nieuwsbrief"
 }


### PR DESCRIPTION
Add the ability to show a newsletter subscription button after successfully submitting a budgeting vote.

Related ticket: https://trello.com/c/HuOjuDOF/589-nieuwsbrief-inschrijven-knop-tonen-na-versturen-budget-stem-fase-2