### PR TITLE
Allow HTML in icon section description

### DIFF
--- a/lib/modules/icon-section-widgets/views/widget.html
+++ b/lib/modules/icon-section-widgets/views/widget.html
@@ -21,8 +21,8 @@
 					<p class="step-text">
 					{#	{{step.description.items[0].content | safe }} #}
 
-            {{step.description}}
-            
+            {{step.description | safe}}
+
 						{% if step.linkUrl %}
 						<ul>
 							<li>


### PR DESCRIPTION
Related ticket: https://trello.com/c/iJHmUFyE/606-in-de-icon-section-beschrijving-moet-html-te-plaatsen-zijn