### PR TITLE
Allow the logo href to be changed in the global settings

### DIFF
--- a/lib/modules/apostrophe-global/index.js
+++ b/lib/modules/apostrophe-global/index.js
@@ -106,6 +106,11 @@ module.exports = {
       trash: true
     },
     {
+      name: 'logoLink',
+      type: 'string',
+      label: 'Where do we want to link the logo towards? (leave empty for default app url)',
+    },
+    {
       name: 'mapCenterLat',
       type: 'float',
       label: 'Map center Latitude',
@@ -328,7 +333,7 @@ module.exports = {
       {
         name: 'design',
         label: 'Vormgeving',
-        fields: ['siteLogo']
+        fields: ['siteLogo', 'logoLink']
       },
       {
         name: 'footer',

--- a/views/layout.html
+++ b/views/layout.html
@@ -95,11 +95,16 @@ ga('send', 'pageview');
   {{ palette.palette(data.global, 'palette') }}
 {% endif %}
     {% if not (data.query.layout === 'none') %}
+    {% if data.global.logoLink %}
+        {% set logoLink = data.global.logoLink %}
+    {% else %}
+        {% set logoLink = appUrl %}
+    {% endif %}
     <header>
         <div class="container relative">
             <div class="row">
                 <div class="col-xs-12">
-                  <a href="{{appUrl}}/" class="logo-container">
+                  <a href="{{logoLink}}/" class="logo-container">
                     {% if data.global.siteLogo %}
                     <img src="{{apos.attachments.url(data.global.siteLogo)}}" alt="logo" id="logo-image">
 


### PR DESCRIPTION
Related ticket: https://trello.com/c/Ro5F1dMk/607-de-url-waar-het-logo-naartoe-linkt-moet-aan-te-passen-zijn