### PR TITLE
Save the sorting of ideas on random order

### DIFF
--- a/lib/modules/apostrophe-assets/public/js/sort.js
+++ b/lib/modules/apostrophe-assets/public/js/sort.js
@@ -39,12 +39,37 @@ $(document).ready(function($) {
   });
 });
 
+
+
 function sortElements(arg, order, sel, elem) {
         var $selector = $(sel),
         $element = $selector.find(elem);
 
         if (arg === 'random') {
-          $element.shuffle();
+            var randomOrder = window.localStorage.getItem('randomOrder');
+        
+            if (randomOrder) {
+                randomOrder = JSON.parse(randomOrder);
+            }
+    
+            // Do we have a saved order in our local storage with the same amount of plans?
+            // If there are new plans then it's better to shuffle the ideas again to ensure randomization
+            if (randomOrder && randomOrder.length === $element.length) {
+                
+                // restore saved order from localstorage
+                $element.sort(function (a, b) {
+                    var l = $.inArray(parseInt($(a).attr('data-ideaid')), randomOrder);
+                    var r = $.inArray(parseInt($(b).attr('data-ideaid')), randomOrder);
+                    return (l < r) ? -1 : (l > r) ? 1 : 0;
+                });
+                
+                $element.detach().appendTo($selector);
+            } else {
+                $element.shuffle();
+            }
+            
+            // Save new random order
+            saveElementsOrder($selector.find(elem));
         } else {
           $element.sort(function(a, b) {
                   var an = parseInt(a.getAttribute('data-'+ arg)),
@@ -65,4 +90,14 @@ function sortElements(arg, order, sel, elem) {
 
           $element.detach().appendTo($selector);
         }
+}
+
+function saveElementsOrder ($elem) {
+    var order = [];
+    
+    $elem.each(function () {
+        order.push($(this).data('ideaid'));
+    });
+    
+    window.localStorage.setItem('randomOrder', JSON.stringify(order));
 }

--- a/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
+++ b/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
@@ -16,6 +16,7 @@
 		data-likes="{{idea.yes}}"
 		data-budget="{{idea.budget}}"
 		data-ranking="{{idea.extraData.ranking}}"
+  		data-ideaid="{{idea.id}}"
 	>
 		<div class="idea-image-mask">
 			<div class="idea-image" style="background-image: url('{{data.widget.formatImageUrl(idea.extraData.images[0], 500, 500, true, idea.location) }}')"></div>

--- a/lib/modules/idea-overview-widgets/views/gridder.html
+++ b/lib/modules/idea-overview-widgets/views/gridder.html
@@ -70,6 +70,7 @@ data-default-sort="{{data.widget.defaultSorting}}"
   data-likes="{{idea.yes}}"
   data-budget="{{idea.budget}}"
   data-ranking="{{idea.extraData.ranking}}"
+  data-ideaid="{{idea.id}}"
   >
     <div class="image-container" style="position: relative;">
     	<div class="image">

--- a/lib/modules/idea-overview-widgets/views/minimalVotes.html
+++ b/lib/modules/idea-overview-widgets/views/minimalVotes.html
@@ -11,6 +11,7 @@
   data-likes="{{idea.yes}}"
   data-budget="{{idea.budget}}"
   data-ranking="{{idea.ranking}}"
+  data-ideaid="{{idea.id}}"
 >
   <a href="/{{data.global.ideaSlug}}/{{idea.id}}">
     {% if idea.status != 'DENIED' and idea.ranking %}


### PR DESCRIPTION
When the user comes back to the overview we restore the order that the
user saw before. When there are new plans (for instance, when the user
visits again the next day) a new random order will be forced and then
saved in local storage.

Related ticket: https://trello.com/c/awBU36dY/574-sorting-willekeurig-plannen-volgorde-onthouden-per-sessie-anders-is-de-volgorde-op-de-overzichtspagina-steeds-anders-na-elk-plan