### PR TITLE
Add ability to select specific share buttons, or none at all

### DIFF
--- a/lib/modules/idea-single-widgets/index.js
+++ b/lib/modules/idea-single-widgets/index.js
@@ -29,7 +29,8 @@ const fields = [
       choices: [
           {
               value: true,
-              label: "Yes"
+              label: "Yes",
+              showFields: ['shareChannelsSelection']
           },
           {
               value: false,
@@ -37,7 +38,31 @@ const fields = [
           },
       ],
       def: true
-  }].concat(
+  },
+  {
+    name: 'shareChannelsSelection',
+    type: 'checkboxes',
+    label: 'Select which share buttons you want to display (if left empty all social buttons will be shown)',
+    choices: [
+        {
+            value: 'facebook',
+            label: "Facebook"
+        },
+        {
+            value: 'twitter',
+            label: "Twitter"
+        },
+        {
+            value: 'mail',
+            label: "E-mail"
+        },
+        {
+            value: 'whatsapp',
+            label: "Whatsapp"
+        },
+    ]
+  }
+].concat(
     ideaStates.map((state) => {
       return {
         type: 'string',

--- a/lib/modules/idea-single-widgets/public/css/main.less
+++ b/lib/modules/idea-single-widgets/public/css/main.less
@@ -357,6 +357,18 @@
 						margin: 0;
 						padding: 0;
 
+						&.desktop {
+							@media only screen and (max-width: 767px) {
+								display: none;
+							}
+						}
+
+						&.mobile {
+							@media only screen and (min-width: 768px) {
+								display: none;
+							}
+						}
+
 						a {
 							background-position: center;
 							background-repeat: no-repeat;

--- a/lib/modules/idea-single-widgets/views/widget.html
+++ b/lib/modules/idea-single-widgets/views/widget.html
@@ -123,14 +123,17 @@
 							{% endif %}
 						</div>
 					</div>
-					{% if data.widget.showShareButtons %}
+					{% if data.widget.showShareButtons !== false %}
 					<div class="share">
 						<h4>Deel dit voorstel</h4>
 						<ul>
-							<li><a class="facebook" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{data.currentUrl}}">Facebook</a></li>
-							<li><a class="twitter"  target="_blank" href="https://twitter.com/intent/tweet?text={{data.currentUrl}}">Twitter</a></li>
-							<li><a class="email"    target="_blank" href="mailto:?subject={{'Idee voor West: '+idea.title | urlencode}}&body={{data.currentUrl | urlencode}}">Email</a></li>
-							<li><a class="whatsapp" target="_blank" href="https://wa.me/?text={{data.currentUrl | urlencode}}">WhatsApp</a></li>
+							{% if not data.widget.shareChannelsSelection or data.widget.shareChannelsSelection.indexOf('facebook') > -1 or data.widget.shareChannelsSelection.length === 0 %}<li><a class="facebook" target="_blank" href="https://www.facebook.com/sharer/sharer.php?u={{data.currentUrl}}">Facebook</a></li>{% endif %}
+							{% if not data.widget.shareChannelsSelection or data.widget.shareChannelsSelection.indexOf('twitter') > -1 or data.widget.shareChannelsSelection.length === 0 %}<li><a class="twitter"  target="_blank" href="https://twitter.com/intent/tweet?text={{data.currentUrl}}">Twitter</a></li>{% endif %}
+							{% if not data.widget.shareChannelsSelection or data.widget.shareChannelsSelection.indexOf('mail') > -1 or data.widget.shareChannelsSelection.length === 0 %}<li><a class="email"    target="_blank" href="mailto:?subject={{'Idee voor West: '+idea.title | urlencode}}&body={{data.currentUrl | urlencode}}">Email</a></li>{% endif %}
+							{% if not data.widget.shareChannelsSelection or data.widget.shareChannelsSelection.indexOf('whatsapp') > -1 or data.widget.shareChannelsSelection.length === 0 %}
+							<li class="desktop"><a class="whatsapp" target="_blank" href="https://wa.me/?text={{data.currentUrl | urlencode}}">WhatsApp</a></li>
+							<li class="mobile"><a class="whatsapp" href="whatsapp://send?text={{data.currentUrl | urlencode}}" data-action="share/whatsapp/share">WhatsApp</a></li>
+							{% endif %}
 						</ul>
 					</div>
 					{% endif %}


### PR DESCRIPTION
Default values are respected, although this is harder to do in
Apostrophe as 'def' does not exist for checkboxes. The logic in the view
is handling the default values.

Related ticket: https://trello.com/c/ob1MLvkB/570-aanpassingen-aan-social-share-buttons