### PR TITLE
Hide empty description on desktop as well

### DIFF
--- a/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
+++ b/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
@@ -103,9 +103,11 @@
 						<div class="intro">
 							{{idea.summary | safe}}
 						</div>
+                        {% if idea.description %}}
 						<div class="description">
 							{{idea.description | safe}}
 						</div>
+                        {% endif %}
 					</div>
 					<div class="share-buttons">
 						<table class="table-center">


### PR DESCRIPTION
Related ticket: https://trello.com/c/JGqWDocB/600-bij-het-idee%C3%ABnoverzicht-tijdens-fase-2-budgeteren-alleen-de-beschrijving-tonen-indien-deze-niet-leeg-is

This is a fix for PR #23 

In that PR we only fixed this issue for mobile, this also fixes it for desktop.