### PR TITLE
Allow combination of BUSY and DENIED status in the overview

### DIFF
--- a/lib/modules/idea-overview-widgets/index.js
+++ b/lib/modules/idea-overview-widgets/index.js
@@ -205,8 +205,25 @@ const fields = [
           name: 'label' +  state.value,
           label: 'Label for: ' + state.value,
         }
-      })
-  );
+      }).concat([
+          {
+              type: 'boolean',
+              name: 'combineDeniedAndBusyStatus',
+              label: 'Combine the DENIED and BUSY status in the overview to both show as DENIED?',
+              choices: [
+                  {
+                    label: 'Yes',
+                    value: true
+                  },
+                  {
+                    label: 'No',
+                    value: false,
+                  }
+              ],
+              def: false,
+          }
+      ])
+);
 
 module.exports = {
   extend: 'apostrophe-widgets',

--- a/lib/modules/idea-overview-widgets/views/minimalVotes.html
+++ b/lib/modules/idea-overview-widgets/views/minimalVotes.html
@@ -6,7 +6,7 @@
 	data-default-sort="{{data.widget.defaultSorting}}"
 	{% endif %}
 >{% for idea in data.widget.ideas %}<div
-  class="tile idea-item {{idea.status}} {{'USER' if data.openstadUser.id === idea.userId}}"
+  class="tile idea-item {% if data.widget.combineDeniedAndBusyStatus and idea.status == 'BUSY' %} DENIED {% else %} {{ idea.status }} {% endif %}} {{'USER' if data.openstadUser.id === idea.userId}}"
   data-createdtime="{{idea.createdTime}}"
   data-likes="{{idea.yes}}"
   data-budget="{{idea.budget}}"
@@ -14,7 +14,7 @@
   data-ideaid="{{idea.id}}"
 >
   <a href="/{{data.global.ideaSlug}}/{{idea.id}}">
-    {% if idea.status != 'DENIED' and idea.ranking %}
+    {% if idea.status != 'DENIED' and (not data.widget.combineDeniedAndBusyStatus or idea.status != 'BUSY') and idea.ranking %}
     <div class="ranking"><div class="label">{{idea.ranking}}</div></div>
     {% endif %}
 


### PR DESCRIPTION
This essentially adds a checkbox which - when checked - will change the
BUSY status to DENIED in the overview. Which allows us to use BUSY for
ideas without enough likes, and DENIED for other ideas. We can then
allow the visitor to filter on 'DENIED' and see both these types of
plans as 'DENIED'. We only show the differentiation between these two
statuses on the idea page.

Related ticket: https://trello.com/c/ID6wk0Ln/614-status-busy-en-denied-samen-kunnen-voegen-in-planoverzicht-voor-archief