### PR TITLE
Add min and max to summary and description

### DIFF
--- a/lib/modules/idea-form-widgets/index.js
+++ b/lib/modules/idea-form-widgets/index.js
@@ -81,6 +81,16 @@ module.exports = {
       ]
   },
   {
+      name: 'minSummary',
+      type: 'float',
+      label: 'Minimum number of characters needed for summary',
+  },
+  {
+      name: 'maxSummary',
+      type: 'float',
+      label: 'Maximum number of characters needed for summary',
+  },
+  {
       name: 'requiredSummary',
       type: 'boolean',
       label: 'This field is required',
@@ -120,6 +130,16 @@ module.exports = {
                   label: "Hide"
               },
           ]
+  },
+  {
+      name: 'minDescription',
+      type: 'float',
+      label: 'Minimum number of characters needed for description',
+  },
+  {
+      name: 'maxDescription',
+      type: 'float',
+      label: 'Maximum number of characters needed for description',
   },
   {
       name: 'requiredDescription',


### PR DESCRIPTION
These fields were never added to development, but they are referenced in the js and html files. Which leads to default which can not be overwritten.