### PR TITLE
Show separator in begroten overview only when necessary

### DIFF
--- a/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
+++ b/lib/modules/begroot-widgets/views/phase-voting/ideas-list.html
@@ -37,7 +37,7 @@ data-default-sort="{{data.widget.defaultSorting}}"
 				<h3 class="title">{{idea.title}}</h3>
 				{% if idea.extraData %}
 				<div class="thema-en-gebied underscription">
-					<span class="thema theme-{{idea.id}}">{{idea.extraData.theme}}</span>{% if idea.extraData.area %} | <span class="gebied area-{{idea.id}}">{{idea.extraData.area}}</span>{% endif %}
+					{% if idea.extraData.theme %}<span class="thema theme-{{idea.id}}">{{idea.extraData.theme}}</span>{% endif %}{% if idea.extraData.theme and idea.extraData.area %} | {% endif %}{% if idea.extraData.area %}<span class="gebied area-{{idea.id}}">{{idea.extraData.area}}</span>{% endif %}
 				</div>
 				{% endif %}
 


### PR DESCRIPTION
Related ticket: https://trello.com/c/XgP4Okgs/602-bij-het-budgeteren-fase-2-moet-het-scheidingsteken-tussen-thema-en-gebied-alleen-tonen-als-thema-en-gebied-beide-ingevuld-zijn