### PR TITLE
Set the default arrow icon color to black on sections

### DIFF
--- a/lib/modules/icon-section-widgets/index.js
+++ b/lib/modules/icon-section-widgets/index.js
@@ -45,7 +45,8 @@ module.exports = {
                     label: 'Black',
                     value: 'arrow_down_black'
                 }
-            ]
+            ],
+            def: 'arrow_down_black',
         },
         {
             name:       'steps',

--- a/lib/modules/section-widgets/index.js
+++ b/lib/modules/section-widgets/index.js
@@ -147,7 +147,7 @@ module.exports = {
           value: true,
           label: "Yes",
           showFields: [
-            'sectionOpen', 'mobileToggle', 'toggleTitle'
+            'sectionOpen', 'mobileToggle', 'toggleTitle', 'typeArrow'
           ]
         },
         {
@@ -175,7 +175,8 @@ module.exports = {
           label: 'Black',
           value: 'arrow_down_black'
         }
-      ]
+      ],
+      def: 'arrow_down_black',
     },
     {
       type: 'boolean',


### PR DESCRIPTION
Related ticket: https://trello.com/c/Gazlf1nM/617-pijltje-icon-sectie-standaard-zwart-bij-wanneer-nieuw-ingevoegd