### PR TITLE
Force a specific language

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,18 @@ apos.define('idea-single-widgets', {
 });
 ```
 
-## Forcing a language
-It's possible to force the application into a specific language by specifying the locale as the `FORCE_LANGUAGE` in the .env file.
-To force the dutch language for example:
+## Defining the allowed locales and setting the default locale
+It's possible to set one or more languages (separated by a comma) through the .env file.
+Both of these definitions are valid:
+
 ```
-FORCE_LANGUAGE=nl
+ALLOW_LOCALES=nl
+
+ALLOW_LOCALES=nl,en
+```
+
+It's also possible to set the default locale through the .env:
+
+```
+DEFAULT_LOCALE=en
 ```

--- a/README.md
+++ b/README.md
@@ -91,3 +91,10 @@ apos.define('idea-single-widgets', {
     }
 });
 ```
+
+## Forcing a language
+It's possible to force the application into a specific language by specifying the locale as the `FORCE_LANGUAGE` in the .env file.
+To force the dutch language for example:
+```
+FORCE_LANGUAGE=nl
+```

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -281,10 +281,19 @@ module.exports = {
       siteConfig.modules['apostrophe-workflow-modified-documents'] = {};
 
     } else {
+      
+      let locales = ['nl', 'en'];
+      let defaultLocale = 'nl';
+      
+      if (process.env.FORCE_LANGUAGE) {
+        locales = [process.env.FORCE_LANGUAGE];
+        defaultLocale = process.env.FORCE_LANGUAGE;
+      }
+      
       siteConfig.modules['apostrophe-i18n'] = {
-        locales: ['nl', 'en'],
+        locales,
         directory: __dirname + '/locales',
-        defaultLocale: 'nl'
+        defaultLocale
       }
     }
 

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -282,12 +282,12 @@ module.exports = {
 
     } else {
       
-      let locales = ['nl', 'en'];
-      let defaultLocale = 'nl';
-      
       if (process.env.FORCE_LANGUAGE) {
-        locales = [process.env.FORCE_LANGUAGE];
-        defaultLocale = process.env.FORCE_LANGUAGE;
+        const locales = [process.env.FORCE_LANGUAGE];
+        const defaultLocale = process.env.FORCE_LANGUAGE;
+      } else {
+        const locales = ['nl', 'en'];
+        const defaultLocale = 'nl';
       }
       
       siteConfig.modules['apostrophe-i18n'] = {

--- a/siteConfig.js
+++ b/siteConfig.js
@@ -282,13 +282,8 @@ module.exports = {
 
     } else {
       
-      if (process.env.FORCE_LANGUAGE) {
-        const locales = [process.env.FORCE_LANGUAGE];
-        const defaultLocale = process.env.FORCE_LANGUAGE;
-      } else {
-        const locales = ['nl', 'en'];
-        const defaultLocale = 'nl';
-      }
+      const locales = process.env.ALLOW_LOCALES ? process.env.ALLOW_LOCALES.split(',') : ['nl', 'en'];
+      const defaultLocale = process.env.DEFAULT_LOCALE || 'nl';
       
       siteConfig.modules['apostrophe-i18n'] = {
         locales,


### PR DESCRIPTION
Currently the system takes the 'Accept-language' header from the browser to determine which language to show. For some websites we want to be able to always force the website in dutch, regardless of the user's preference.

Related ticket: https://trello.com/c/jUTokk7r/649-vertalingen-mogelijkheid-om-%C3%A9%C3%A9n-taal-te-forceren