### PR TITLE
Bugfix/wrong column definitions

### DIFF
--- a/lib/modules/idea-single-widgets/views/widget.html
+++ b/lib/modules/idea-single-widgets/views/widget.html
@@ -155,7 +155,7 @@
 			<p class="summary">
 				<strong>{{(idea.summary or '') | nlbr | sanitize | safe }}</strong>
 			</p>
-			{{(idea.summary or '') | nlbr | sanitize | safe}}
+			{{(idea.description or '') | nlbr | sanitize | safe}}
 		</div>
 		{% if idea.location %}
 		<br/><br/>

--- a/lib/modules/section-widgets/views/types/columns-onefourth.html
+++ b/lib/modules/section-widgets/views/types/columns-onefourth.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-sm-4 col-xs-12">
+  <div class="col-sm-3 col-xs-12">
       {{
         apos.area(data.widget, 'area1', {
           widgets: apos.settings.getOption('contentWidgets')
@@ -7,7 +7,7 @@
       }}
     </div>
 
-    <div class="col-sm-8 col-xs-12">
+    <div class="col-sm-9 col-xs-12">
       {{
         apos.area(data.widget, 'area2', {
           widgets: apos.settings.getOption('contentWidgets')

--- a/lib/modules/section-widgets/views/types/columns-onethird.html
+++ b/lib/modules/section-widgets/views/types/columns-onethird.html
@@ -1,5 +1,5 @@
 <div class="row">
-  <div class="col-sm-3 col-xs-12">
+  <div class="col-sm-4 col-xs-12">
       {{
         apos.area(data.widget, 'area1', {
           widgets: apos.settings.getOption('contentWidgets')
@@ -7,7 +7,7 @@
       }}
     </div>
 
-    <div class="col-sm-9 col-xs-12">
+    <div class="col-sm-8 col-xs-12">
       {{
         apos.area(data.widget, 'area2', {
           widgets: apos.settings.getOption('contentWidgets')


### PR DESCRIPTION
Columns: 25/75 en 33/66 omdraaien. Die staan nu precies verkeerdom ingesteld in Apostrophe.

https://trello.com/c/7aCKGsbc/33-columns-25-75-en-33-66-omdraaien-die-staan-nu-precies-verkeerdom-ingesteld-in-apostrophe