### PR TITLE
fix apostrophe error warnings

### DIFF
--- a/packages/cms/config/siteConfig.js
+++ b/packages/cms/config/siteConfig.js
@@ -13,6 +13,7 @@ module.exports = {
       modules: {
         'api-proxy': {},
         'settings': {
+          ignoreNoCodeWarning: true,
           // So we can write `apos.settings` in a template
           alias: 'settings',
           apiUrl: process.env.API,
@@ -53,9 +54,6 @@ module.exports = {
         'apostrophe-palette': {},
         'apostrophe-video-widgets': {},
         'apostrophe-area-structure': {},
-        'apostrophe-multisite-patch-assets': {},
-        'apostrophe-docs': {},
-        'openstad-docs': {},
         'openstad-areas': {},
         'openstad-widgets': {},
         'openstad-users': {},
@@ -108,7 +106,6 @@ module.exports = {
         'openstad-logger': {},
         'idea-pages': {},
         'section-widgets': {},
-        'all-on-one-row-widgets': {},
         'card-widgets': {},
         'iframe-widgets': {},
         'speech-bubble-widgets': {},
@@ -141,7 +138,6 @@ module.exports = {
         'begroot-widgets': {},
         'choices-guide-widgets': {},
         'local-video-widgets': {},
-        'one-row-widgets': {},
         'image-widgets': {},
         'location-widgets': {},
         'share-widgets': {},

--- a/packages/cms/lib/modules/begroot-widgets/index.js
+++ b/packages/cms/lib/modules/begroot-widgets/index.js
@@ -12,10 +12,6 @@ const fields = [
       {
         label: 'Yes',
         value: true,
-        showFields: [
-          'vote_block_show_text_1',
-          'vote_block_show_text_2',
-        ]
       },
       {
         label: 'No',

--- a/packages/cms/lib/modules/openstad-global/lib/fields.js
+++ b/packages/cms/lib/modules/openstad-global/lib/fields.js
@@ -219,20 +219,6 @@ module.exports = [
         label: 'Openstreet Maps ServerUrl (not implemented yet)',
     },
     {
-        name: 'areas',
-        type: 'array',
-        titleField: 'label',
-        label: 'Buurten',
-        schema: [
-            {
-                name: 'value',
-                type: 'text',
-                label: 'Name',
-                type: 'string',
-            }
-        ]
-    },
-    {
         name: 'themes',
         type: 'array',
         titleField: 'label',
@@ -375,11 +361,6 @@ module.exports = [
                 label: 'Open in new tab',
             },
         ]
-    },
-    {
-        name: 'displayLoginTopLink',
-        type: 'boolean',
-        label: 'Display login and logout link in top links?'
     },
     {
         name: 'displayMyAcount',

--- a/packages/cms/lib/modules/participatory-budgeting-widgets/lib/fields.js
+++ b/packages/cms/lib/modules/participatory-budgeting-widgets/lib/fields.js
@@ -10,10 +10,6 @@ const fields = [
       {
         label: 'Yes',
         value: true,
-        showFields: [
-          'vote_block_show_text_1',
-          'vote_block_show_text_2',
-        ]
       },
       {
         label: 'No',

--- a/packages/cms/lib/modules/resource-overview-widgets/lib/fields.js
+++ b/packages/cms/lib/modules/resource-overview-widgets/lib/fields.js
@@ -14,7 +14,7 @@ module.exports = [
           {
             label: 'Uitklap',
             value: 'gridder',
-            showFields: ['gridder_text_open', 'gridder_text_vote_button', 'gridder_open_text_vote_button', 'gridder_tile_image_aspect_ratio', 'gridder_use_field_as_title', 'showVoteCounter']
+            showFields: ['gridder_text_open', 'gridder_tile_image_aspect_ratio', 'gridder_use_field_as_title', 'showVoteCounter']
           },
           {
             label: 'Row',


### PR DESCRIPTION
This is the only warning that's still open:
`⚠️ doc type apostrophe-global contains unarranged field(s): modbreakAuthor, themes.`