### PR TITLE
Apply oembetter whitelist to openGraph requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
 
+## 0.7.1
+* Hotfix: apply oembetter whitelist to openGraph requests to prevent SSRF
+
 ## 0.7.0 (2020-10-15)
 * Start of using version numbers in changelog

--- a/packages/cms/config/siteConfig.js
+++ b/packages/cms/config/siteConfig.js
@@ -116,6 +116,7 @@ module.exports = {
         'attachment-upload': {},
         'openstad-nunjucks-filters': {},
         'openstad-custom-pages': {},
+        'openstad-oembed': {},
 
 
         // Apostrophe module configuration

--- a/packages/cms/lib/modules/openstad-oembed/index.js
+++ b/packages/cms/lib/modules/openstad-oembed/index.js
@@ -1,0 +1,49 @@
+const urls = require('url');
+
+module.exports = {
+  improve: 'apostrophe-oembed',
+  construct: function (self, options) {
+    
+    const superOpenGraph = self.openGraph;
+    
+    self.openGraph = function (req, url, callback) {
+      // To prevent SSRF, we check if the requested URL is whitelisted before
+      // performing a request and building the oembed response.
+      if (url.match(/^\/\//)) {
+        // Protocol-relative URLs are commonly found
+        // in markup these days and can be upgraded
+        // to https so that they work
+        url = 'https:' + url;
+      }
+      
+      const parsed   = urls.parse(url);
+      
+      if (!parsed) {
+        return callback(new Error('oembetter openGraph: invalid URL: ' + url));
+      }
+      
+      if ((parsed.protocol !== 'http:') && (parsed.protocol !== 'https:')) {
+        return callback(new Error('oembetter openGraph: URL is neither http nor https: ' + url));
+      }
+      
+      if (self.oembetter._whitelist) {
+        let good = false;
+        for (i = 0; (i < self.oembetter._whitelist.length); i++) {
+          if (!parsed.hostname) {
+            continue;
+          }
+          if (self.oembetter.inDomain(self.oembetter._whitelist[i], parsed.hostname)) {
+            good = true;
+            break;
+          }
+        }
+        if (!good) {
+          // We can return a status code instead of a complete error
+          return callback(500);
+        }
+      }
+      
+      return superOpenGraph(req, url, callback);
+    }
+  }
+}


### PR DESCRIPTION
Apostrophe-oembed uses a default whitelist for all oembed checks. If the oembed check fails (for whatever reason) an openGraph fallback request is performed, unless `neverOpenGraph` is set to `1` in the query.

The openGraph fallback request does not take the whitelist into consideration. This means that we can perform requests to whichever URL we desire from the server (SSRF).

This hotfix adds the whitelist check as performed in the oembed fetch request. In an ideal situation this should be solved in the apostrophecms source.

### Example exploits
This bug can be exploited to check if files exist;

A GET request to `https://westbegroot.amsterdam.nl/modules/apostrophe-oembed/query?url=http://127.0.0.1.xip.io:80/index.html&neverOpenGraph=0` will return a '200' status code, indicating that the file exists.

A GET request to `https://westbegroot.amsterdam.nl/modules/apostrophe-oembed/query?url=http://127.0.0.1.xip.io:80/doesnt_exist.html&neverOpenGraph=0` will return a '404' status code, indicating that the file does not exist.

This exploit can also be used to check if a port is open;

`https://westbegroot.amsterdam.nl//modules/apostrophe-oembed/query?url=http://127.0.0.1.xip.io:81/index.html&neverOpenGraph=0` will return '404', indicating that the port `81` is not open.
