### PR TITLE
Fix incorrect closing tag in slider widget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Update apostrophe to 2.113.0 for @openstad/cms & run `npm update` in root to fix a YouTube oembed bug
 * Add an oembed API endpoint to siteConfig for vimeo.com videos to prevent Vimeo blocking scrapes from oembetter
 * Fix bug in Participatory Budgeting where removing ideas in the selection was stored wrongly.
+* Fix incorrect closing tag in slider widget
 
 ## v0.12.0 (2020-01-27)
 * Allow for running multiple sites on subdirectories

--- a/packages/cms/lib/modules/slider-widgets/views/widget.html
+++ b/packages/cms/lib/modules/slider-widgets/views/widget.html
@@ -11,8 +11,8 @@
                     <div class="imgdiv"
                         style="background-image: url({{ apos.attachments.url(item.image) }})"
                     >
-                        <img class="button button-left" src="{{data.siteUrl}}/modules/openstad-assets/img/button-arrow-blue.svg"></modules/openstad-assets/img>
-                        <img class="button button-right" src="{{data.siteUrl}}/modules/openstad-assets/img/button-arrow-blue.svg"></modules/openstad-assets/img>
+                        <img class="button button-left" src="{{data.siteUrl}}/modules/openstad-assets/img/button-arrow-blue.svg" />
+                        <img class="button button-right" src="{{data.siteUrl}}/modules/openstad-assets/img/button-arrow-blue.svg" />
 
                     </div>
                 </div>


### PR DESCRIPTION
The replacement for relative URLs has been a bit too rigorous, where the `</img>` tag has now been replaced by a `</modules/openstad-assets/img>` tag in the slider widget.

This PR sets the correct closing tag for the img