### PR TITLE
Make autoCenter configurable in idea-map-widgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,6 @@
 # Changelog
+## Unreleased
+* Make autoCenter configurable in idea-map-widgets
 
 ## v0.19.0 (2021-08-17)
 * Better settings for closed reactions on idea-on-map

--- a/packages/cms/lib/modules/idea-map-widgets/index.js
+++ b/packages/cms/lib/modules/idea-map-widgets/index.js
@@ -80,6 +80,11 @@ module.exports = {
       ]
     },
     {
+      type: 'boolean',
+      name: 'autoCenter',
+      label: 'Enable auto center (this option will automatically calculate the center of the map based on the markers and polygon',
+    },
+    {
       type: 'string',
       name: 'filterIdeas',
       label: 'Show only following ideas: (idea id\'s, comma seperated)',
@@ -100,7 +105,7 @@ module.exports = {
       {
         name: 'map',
         label: 'Map',
-        fields: ['useMarkerLinks']
+        fields: ['useMarkerLinks', 'autoCenter']
       },
       {
         name: 'ctaButon',
@@ -182,7 +187,8 @@ module.exports = {
               mapZoomLevel: globalData.mapZoomLevel,
               styles: styles,
               useMarkerLinks: widget.useMarkerLinks,
-              googleMapsApiKey: googleMapsApiKey
+              googleMapsApiKey: googleMapsApiKey,
+              autoCenter: widget.autoCenter
             })
             .setPolygon(globalData.mapPolygons)
             .setMarkersByResources(widget.ideas)

--- a/packages/cms/lib/modules/idea-map-widgets/index.js
+++ b/packages/cms/lib/modules/idea-map-widgets/index.js
@@ -82,7 +82,7 @@ module.exports = {
     {
       type: 'boolean',
       name: 'autoCenter',
-      label: 'Enable auto center (this option will automatically calculate the center of the map based on the markers and polygon',
+      label: 'Enable auto center (this option will automatically calculate the center of the map based on the markers and polygon)',
     },
     {
       type: 'string',

--- a/packages/cms/lib/modules/idea-map-widgets/public/js/main.js
+++ b/packages/cms/lib/modules/idea-map-widgets/public/js/main.js
@@ -11,7 +11,9 @@ apos.define('idea-map-widgets', {
                 var markers = self.addMarkers(mapConfig);
                 self.addOverviewEventListeners(map);
 
-                self.center();
+                if(mapConfig.defaultSettings && mapConfig.defaultSettings.autoCenter) {
+                    self.center();
+                }
             }
 
             /**

--- a/packages/cms/lib/modules/idea-map-widgets/public/js/main.js
+++ b/packages/cms/lib/modules/idea-map-widgets/public/js/main.js
@@ -11,6 +11,8 @@ apos.define('idea-map-widgets', {
                 var markers = self.addMarkers(mapConfig);
                 self.addOverviewEventListeners(map);
 
+                // If autoCenter is set use the the center functionality to automatically center the map based on the markers and polygon.
+                // Otherwise it will use the default/global settings to set the center and zoom level of the map.
                 if(mapConfig.defaultSettings && mapConfig.defaultSettings.autoCenter) {
                     self.center();
                 }

--- a/packages/cms/lib/modules/map-widgets/lib/map-data.js
+++ b/packages/cms/lib/modules/map-widgets/lib/map-data.js
@@ -144,7 +144,8 @@ module.exports = class MapConfigBuilder {
             useMarkerLinks: settings.useMarkerLinks === false || settings.useMarkerLinks == 'false' ? false : true,
             disableDefaultUI: settings.disableDefaultUI || true,
             styles: settings.styles || null,
-            googleMapsApiKey: settings.googleMapsApiKey || ''
+            googleMapsApiKey: settings.googleMapsApiKey || '',
+            autoCenter: settings.autoCenter === false || settings.autoCenter == 'false' ? false : true,
         };
 
         return this;


### PR DESCRIPTION
In some cases you want to use the manually center and zoom settings because the auto center logic also adjust the zoom level.