### PR TITLE
Restructure participatory widget fields

### DIFF
--- a/locales/default.json
+++ b/locales/default.json
@@ -661,5 +661,12 @@
 	"Alles": "Alles",
 	"Ja/Voor": "Ja/Voor",
 	"Nee/tegen": "Nee/tegen",
-	"Edit Iframe": "Edit Iframe"
+	"Edit Iframe": "Edit Iframe",
+	"Voting options": "Voting options",
+	"Display options": "Display options",
+	"Sorting options": "Sorting options",
+	"Explanation texts": "Explanation texts",
+	"Authentication": "Authentication",
+	"Labels": "Labels",
+	"Display Original Idea Url": "Display Original Idea Url"
 }

--- a/packages/cms/lib/modules/arguments-block-widgets/index.js
+++ b/packages/cms/lib/modules/arguments-block-widgets/index.js
@@ -18,7 +18,6 @@ module.exports = {
   construct: function(self, options) {
 
     options.arrangeFields = (options.arrangeFields || []).concat([
-
       {
         name: 'general',
         label: 'Algemeen',

--- a/packages/cms/lib/modules/participatory-budgeting-widgets/index.js
+++ b/packages/cms/lib/modules/participatory-budgeting-widgets/index.js
@@ -1,12 +1,49 @@
 const sortingOptions = require('../../../config/sorting.js').options;
 const googleMapsApiKey = process.env.GOOGLE_MAPS_API_KEY;
 const fields = require('./lib/fields.js');
+const ideaStates = require('../../../config/idea.js').states;
 
 module.exports = {
     extend: 'map-widgets',
     label: 'Begroot',
     addFields: fields,
     construct: function (self, options) {
+        options.arrangeFields = (options.arrangeFields || []).concat([
+            {
+                name: 'voting-options',
+                label: 'Voting options',
+                fields: ['voting', 'votingType', 'maxIdeas', 'minIdeas', 'initialAvailableBudget', 'minimalBudgetSpent']
+            },
+            {
+                name: 'display-options',
+                label: 'Display options',
+                fields: ['displayRanking', 'displayBudgetLabel', 'showVoteCount', 'unavailableButton','displayOriginalIdeaUrl', 'originalIdeaUrl']
+            },
+            {
+                name: 'sorting-options',
+                label: 'Sorting options',
+                fields: ['selectedSorting', 'defaultSorting']
+            },
+            {
+                name: 'explanation-texts',
+                label: 'Explanation texts',
+                fields: ['step_1_intro', 'step_2_intro', 'step_3_intro', 'step_3_succesfull_auth', 'thankyou_message', 'showNewsletterButton', 'newsletterButtonText']
+            },
+            {
+                name: 'authentication',
+                label: 'Authentication',
+                fields: ['authEmbeddedForm', 'authFormUniqueCodelabel', 'authFormUniqueCodeButtonText', 'authFormSmslabel' , 'authFormSmsButtonText', 'authFormUrllabel', 'authFormUrlButtonText', 'scrollBackToBudgetBlock']
+            },
+            {
+                name: 'labels',
+                label: 'Labels',
+                fields: [].concat(
+                  ideaStates.map((state) => {
+                    return'label' +  state.value
+                }))
+            },
+        ]);
+
         const superPushAssets = self.pushAssets;
         self.pushAssets = function () {
             superPushAssets();
@@ -29,11 +66,9 @@ module.exports = {
             self.pushAsset('script', 'voting', {when: 'always'});
             self.pushAsset('script', 'westbegroot-enhancements', {when: 'always'});
             self.pushAsset('script', 'main', {when: 'always'});
-
         };
 
         const superOutput = self.output;
-
 
         self.output = function (widget, options) {
             const siteConfig = options.siteConfig;
@@ -62,9 +97,15 @@ module.exports = {
                 return url;
             }
 
-
             widget.userHasVoted = false;
             widget.userIsLoggedIn = false;
+
+
+            // in case the it's empty set to true
+            // for backwards compatibility
+            if (widget.displayOriginalIdeaUrl !== false) {
+                widget.displayOriginalIdeaUrl = true;
+            }
 
 
             return superOutput(widget, options);

--- a/packages/cms/lib/modules/participatory-budgeting-widgets/lib/fields.js
+++ b/packages/cms/lib/modules/participatory-budgeting-widgets/lib/fields.js
@@ -34,8 +34,9 @@ const fields = [
     ],
     def: false
   },
+  /*
   {
-    name: 'showRanking',
+    name: 'displayRanking',
     label: 'Show ranking?',
     type: 'boolean',
     choices: [
@@ -50,6 +51,8 @@ const fields = [
     ],
     def: true
   },
+ 
+   */
   {
     name: 'votingType',
     type: 'select',
@@ -110,6 +113,22 @@ const fields = [
     type: 'boolean',
     label: 'Display price label',
     def: true
+  },
+  {
+    name: 'displayOriginalIdeaUrl',
+    type: 'select',
+    def: false,
+    choices: [
+      {
+        label: 'Yes',
+        value: true,
+        showFields: ['originalIdeaUrl']
+      },
+      {
+        label: 'No',
+        value: false,
+      }
+    ]
   },
   {
     name: 'originalIdeaUrl',
@@ -230,17 +249,20 @@ const fields = [
       {
         value: 'url',
         //  label: 'Newest first',
-        label: 'Email login url'
+        label: 'Email login url',
+        showFields: ['authFormUrllabel', 'authFormUrlButtonText']
       },
       {
         value: 'uniqueCode',
         //  label: 'Newest first',
-        label: 'Voting code'
+        label: 'Voting code',
+        showFields: ['authFormUniqueCodelabel', 'authFormUniqueCodeButtonText']
       },
       {
         value: 'sms',
         //  label: 'Newest first',
-        label: 'Sms'
+        label: 'Sms',
+        showFields: ['authFormSmslabel' , 'authFormSmsButtonText']
       },
 
     ]

--- a/packages/cms/lib/modules/participatory-budgeting-widgets/views/phase-voting/ideas-list.html
+++ b/packages/cms/lib/modules/participatory-budgeting-widgets/views/phase-voting/ideas-list.html
@@ -23,8 +23,8 @@ data-default-sort="{{data.widget.defaultSorting}}"
 	data-createdtime="{{idea.createdTime}}"
 	data-likes="{{idea.yes}}"
 	data-budget="{{idea.budget}}"
-  data-ideaid="{{idea.id}}"
-	data-ranking="{{idea.extraData.ranking if (idea.extraData.ranking and data.widget.showRanking) else 10000}}"
+  	data-ideaid="{{idea.id}}"
+	data-ranking="{{idea.extraData.ranking if (idea.extraData.ranking and data.widget.displayRanking) else 10000}}"
 	data-theme="{{idea.extraData.theme}}"
 	data-area="{{idea.extraData.area}}"
 	role="article"
@@ -83,7 +83,7 @@ data-default-sort="{{data.widget.defaultSorting}}"
 				</div>
 			</div>
 			<div class="budget-value"><span class="sr-only">{{ __('Kosten:') }}</span>{{idea.budget}}</div>{# used by sort #}
-			<div class="ranking-value">{{idea.extraData.ranking if (idea.extraData.ranking and data.widget.showRanking) else 0}}</div>
+			<div class="ranking-value">{{idea.extraData.ranking if (idea.extraData.ranking and data.widget.displayRanking) else 0}}</div>
 		</div>
 
 		{# extra info for gridder-show #}
@@ -160,7 +160,7 @@ data-default-sort="{{data.widget.defaultSorting}}"
 					</table>
 					{% endif %}
 					<br />
-					{% if data.widget.originalIdeaUrl and not idea.extraData.hideOriginalLink %}
+					{% if data.widget.displayOriginalIdeaUrl and data.widget.originalIdeaUrl and not idea.extraData.hideOriginalLink %}
 					{% set originalId = idea.extraData.originalId if idea.extraData.originalId else idea.id %}
 					<div class="margin-hor-10">
 						<a href="{{data.widget.originalIdeaUrl | safeRelativeUrl}}/{{originalId}}" class="link-original link-caret--blue" target="_blank">Bekijk het originele voorstel</a>


### PR DESCRIPTION
Dutch:

- nieuwe tabs creëren voor de verschillende onderdelen.
- Er staat twee keer iets in over 'ranking' (Display ranking en 'Show ranking?'). 'Show ranking?' doet niks - deze weg halen. Display ranking doet het wel. Die mag blijven.
- Bij authenticatie alleen de label opties tonen bij de gekozen authenticatie optie
- Bij 'Url where orginal urls are found' Optie toevoegen 'Do you want to include a link to the original ideas?' yes/no. Indien yes: URL veld laten zien en required maken