### PR TITLE
Accessibility retest - first batch of fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,16 @@
 * Add CMS_DEFAULTS to environment vars; specifically analyticsType and analyticsCodeBlock
 * Reorganise Participatory Budget fields in widget
 * Reorganise Status Label fields in Resource Overview widget
+* Add first batch of accessibility fixes from retest
+  * Add an accessible location field to the resource form
+  * Add screen reader labels to the filter input fields above the resource overview. Also an autocomplete attribute was added to the resource overview filter.
+  * Add a focus indicator to the thumbs up button inside an argument form
+  * Update the red amsterdam variable and changed old hex codes to the @amsterdam-red variable
+  * Change the html order of the menu so that the focus goes directly into the submenu.
+  * Add the aria-current attribute to the current page menu item
+  * Add a screen reader only text to the voting progress bar at a single idea page and in the ideas in the resource overview.
+  * Add a focus psuedo element to the delete button in the participatory budgeting widget.
+  * Change the javascript so that the message for the characters in a form is accessible and audible.
 
 ## v0.20.2
 * Fix resource overview widget error: TypeError: Cannot read property 'automaticallyUpdateStatus' of undefined

--- a/packages/cms/lib/modules/arguments-widgets/public/css/main.less
+++ b/packages/cms/lib/modules/arguments-widgets/public/css/main.less
@@ -192,6 +192,13 @@ form.newArgument {
     float: left;
     padding: 5px 0;
 
+		&:focus-within {
+			outline: 2px dotted #000 !important;
+			outline-offset: -2px !important;
+			-webkit-box-shadow: inset 0 0 0 2px #fff !important;
+			box-shadow: inset 0 0 0 2px #fff !important;
+		}
+
 		button {
 			cursor: pointer;
 	    outline: none;

--- a/packages/cms/lib/modules/openstad-assets/public/css/tab-selector.less
+++ b/packages/cms/lib/modules/openstad-assets/public/css/tab-selector.less
@@ -44,7 +44,7 @@
 
 				&.active {
 					border: solid 1px #000000;
-					background-color: #ea1d25;
+					background-color: @amsterdam-red;
 					color:white;
 				}
 
@@ -125,7 +125,7 @@
 
 		&.active {
 			color: white;
-			background-color: #ea1d25;
+			background-color: @amsterdam-red;
 			background-image: url('/modules/openstad-assets/img/arrow_down_white.svg');
 		}
 

--- a/packages/cms/lib/modules/openstad-assets/public/css/variables.less
+++ b/packages/cms/lib/modules/openstad-assets/public/css/variables.less
@@ -43,7 +43,7 @@
 @amsterdam-skyblue: #2b9ad6;
 @amsterdam-lightgreen: #bdd131;
 @amsterdam-green: #a8b900;
-@amsterdam-red: #ea1d25;
+@amsterdam-red: #ec0000;
 
 
 .appearance( @value ) {

--- a/packages/cms/lib/modules/openstad-assets/public/img/share-email-hover.svg
+++ b/packages/cms/lib/modules/openstad-assets/public/img/share-email-hover.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="30" height="30" viewBox="0 0 30 30">
     <g fill="none" fill-rule="evenodd">
-        <path fill="#EA1D25" d="M0 0h30v30H0z"/>
+        <path fill="#EC0000" d="M0 0h30v30H0z"/>
         <path fill="#FFF" fill-rule="nonzero" stroke="#FFF" stroke-width=".75" d="M5 9v13h20V9H5zm9.95 8.052L6.774 9.97h16.355l-8.177 7.082zm-3.25-1.455l-5.715 4.948v-9.993l5.715 5.045zm.69.582l2.56 2.134 2.562-2.134 5.715 4.948H6.773l5.616-4.948zm5.812-.582l5.714-4.948v9.896l-5.714-4.948z"/>
     </g>
 </svg>

--- a/packages/cms/lib/modules/openstad-assets/public/js/site.js
+++ b/packages/cms/lib/modules/openstad-assets/public/js/site.js
@@ -125,12 +125,15 @@ function initToggleMenuVisibility() {
         if ($target.is(':visible')) {
             $('.body-background').hide();
             $('.visibility-toggle').removeClass('active');
+            $('.visibility-toggle').attr('aria-expanded', 'false');
             $('.toggle-menu').removeClass('active').hide();
         } else {
             $('.visibility-toggle').removeClass('active');
+            $('.visibility-toggle').attr('aria-expanded', 'false');
             $('.toggle-menu').removeClass('active').hide();
             $('.body-background').show();
             $button.addClass('active');
+            $button.attr('aria-expanded', 'true');
             $target.addClass('active').show();
         }
     });
@@ -138,6 +141,7 @@ function initToggleMenuVisibility() {
     $('.body-background').click(function (e) {
         $('.body-background').hide();
         $('.visibility-toggle').removeClass('active');
+        $('.visibility-toggle').attr('aria-expanded', 'false');
         $('.toggle-menu').removeClass('active').hide();
     });
 }

--- a/packages/cms/lib/modules/participatory-budgeting-widgets/public/css/button-add.less
+++ b/packages/cms/lib/modules/participatory-budgeting-widgets/public/css/button-add.less
@@ -48,7 +48,8 @@
 			content: "Toegevoegd";
 		}
 
-		&:hover {
+		&:hover,
+		&:focus {
 			outline: 0;
 			color: #434343;
 			background: white;

--- a/packages/cms/lib/modules/participatory-budgeting-widgets/public/css/helpers.less
+++ b/packages/cms/lib/modules/participatory-budgeting-widgets/public/css/helpers.less
@@ -82,3 +82,7 @@ table.thema-en-gebied {
 		 }
 	}
 }
+
+[data-apos-widget="participatory-budgeting"] .begroot-container .ideasList #themaSelector.active + a.inactive {
+	opacity: 1;
+}

--- a/packages/cms/lib/modules/recource-like-widgets/public/css/main.less
+++ b/packages/cms/lib/modules/recource-like-widgets/public/css/main.less
@@ -59,7 +59,7 @@
         }
       }
       &.selected[value="no"] {
-        background-color: #ea1d25;
+        background-color: @amsterdam-red;
         &:disabled {
           background-color: #bebebe;
         }
@@ -81,7 +81,7 @@
         &.selected[value="no"] {
           &:disabled {
             opacity: 0.5;
-            background-color: #ea1d25;
+            background-color: @amsterdam-red;
           }
         }
       }

--- a/packages/cms/lib/modules/recource-raw-widgets/public/css/main.less
+++ b/packages/cms/lib/modules/recource-raw-widgets/public/css/main.less
@@ -215,7 +215,7 @@
 						}
 					}
 					&.selected[value="no"] {
-						background-color: #ea1d25;
+						background-color: @amsterdam-red;
 						&:disabled {
   						background-color: #bebebe;
 						}
@@ -237,7 +237,7 @@
 						&.selected[value="no"] {
 							&:disabled {
 								opacity: 0.5;
-								background-color: #ea1d25;
+								background-color: @amsterdam-red;
 							}
 						}
 					}

--- a/packages/cms/lib/modules/resource-form-widgets/public/js/main.js
+++ b/packages/cms/lib/modules/resource-form-widgets/public/js/main.js
@@ -298,8 +298,21 @@ function initCharsLeftInfo(target, contentDiv, minLen, maxLen, isHTML) {
 
 		msg[enable].className  = enable + ' ' + ( ok ? 'ok' : 'error' ) + ' visible';
 		msg[disable].className = disable;
-		span[enable].innerHTML = chars;
-	}
+		//span[enable].innerHTML = chars;
+
+		msg[enable].setAttribute("aria-live", "polite");
+		msg[disable].removeAttribute("aria-live");
+
+		var innerHTML = msg[enable].innerHTML;
+		chars = chars - 1;
+
+      var output = innerHTML.replace("<span>", "").replace("</span>", "");
+      output = output.replace(/nog \d* tekens/g, 'nog ' + chars + ' tekens');
+      output = output.replace(/minimaal \d* tekens/g, 'minimaal ' + chars + ' tekens');
+
+      msg[enable].innerHTML = '';
+        msg[enable].innerHTML = output;
+    }
 
 }
 

--- a/packages/cms/lib/modules/resource-form-widgets/views/includes/openstad-map.html
+++ b/packages/cms/lib/modules/resource-form-widgets/views/includes/openstad-map.html
@@ -5,6 +5,17 @@
 {% endif %}
 
 <div id="nlmaps-holder" style="width: 100%; height: 100%;">
+	<div class="accessible-location">
+		<input
+				type="text"
+				tabindex="0"
+				id="accessible_location"
+				name="accessible_location"
+				class="sr-only sr-only-focusable"
+				title="{{ __('Enter the location manually') }}"
+				placeholder="{{ __('Enter the location manually') }}"
+				aria-labelledby="location_label" >
+	</div>
 	<div id="map-with-buttons-container">
 		<div class="map-buttons-container">
 			{% if (data.widget.displayCounter) %}

--- a/packages/cms/lib/modules/resource-overview-widgets/views/display/minimalVotes.html
+++ b/packages/cms/lib/modules/resource-overview-widgets/views/display/minimalVotes.html
@@ -58,7 +58,11 @@ data-default-sort="{{data.widget.defaultSorting}}"
 
           {% if data.widget.displayVoteProgressBar %}
           <div class="ideaProgress">
-            <div class="progress"><div class="bar {{idea.status}}" style="width: {{idea.progress}}%;"></div></div>
+            <div class="progress">
+          <div class="bar {{idea.status}}" style="width: {{idea.progress}}%;">
+            <span class="sr-only">Aantal stemmen voor het plan: {{idea.yes}} van de {{data.global.siteConfig.ideas.minimumYesVotes}}.</span>
+          </div>
+        </div>
           </div>
           {% endif %}
           <div class="ideaStats">
@@ -79,7 +83,7 @@ data-default-sort="{{data.widget.defaultSorting}}"
                     </button>
                   </form>
                   {% elseif (data.widget.displayVoteForCount) %}
-                  <div class="count yes">{{idea.yes}}</div>
+                  <div class="count yes"><span class="sr-only">Stemmen voor: </span>{{idea.yes}}<span class="sr-only">. </span></div>
                   {% endif %}
                 </td>
 
@@ -99,7 +103,7 @@ data-default-sort="{{data.widget.defaultSorting}}"
                     </button>
                   </form>
                   {% elseif (data.widget.displayVoteForCount) %}
-                  <div class="count no">{{idea.no}}</div>
+                  <div class="count no"><span class="sr-only">Stemmen tegen: </span>{{idea.no}}</div>
                   {% endif %}
                 </td>
                 {% endif %}

--- a/packages/cms/lib/modules/resource-overview-widgets/views/includes/controls/area.html
+++ b/packages/cms/lib/modules/resource-overview-widgets/views/includes/controls/area.html
@@ -1,5 +1,6 @@
 {% if data.widget.displayAreaFilter %}
-<select class="default-select openstad-ajax-refresh-input" name="area" data-reset-pagination="1">
+<label for="resource-overview-area" class="sr-only">Selecteer een gebied: </label>
+<select id="resource-overview-area" class="default-select openstad-ajax-refresh-input" name="area" data-reset-pagination="1">
   <option value="">Alle gebieden</option>
   {% for area in data.widget.areas %}
   <option value="{{area.value}}" {% if area.value === data.query.area %} selected {% endif %}>{{area.value}}</option>

--- a/packages/cms/lib/modules/resource-overview-widgets/views/includes/controls/search.html
+++ b/packages/cms/lib/modules/resource-overview-widgets/views/includes/controls/search.html
@@ -1,6 +1,7 @@
 {% if data.widget.displaySearch %}
 <div class="search-wrapper">
-  <input type="text" placeholder="Zoeken" name="search" value="{{data.query.search}}" class="search openstad-ajax-refresh-input" onkeyup="console.log(this); $(this).siblings('button').addClass('active'); $(this).siblings('.search-reset').removeClass('active');">
+  <label for="resource-overview-search" class="sr-only">Zoeken naar: </label>
+  <input type="text" placeholder="Zoeken" name="search" value="{{data.query.search}}" id="resource-overview-search" class="search openstad-ajax-refresh-input" onkeyup="console.log(this); $(this).siblings('button').addClass('active'); $(this).siblings('.search-reset').removeClass('active');">
 
   <a type="submit" class="search-reset openstad-ajax-refresh-click {{'active' if data.query.search}}" data-reset-search="1">
     <img src="{{appUrl}}/modules/openstad-assets/img/close.svg" width="16" height="16" />

--- a/packages/cms/lib/modules/resource-overview-widgets/views/includes/controls/sort.html
+++ b/packages/cms/lib/modules/resource-overview-widgets/views/includes/controls/sort.html
@@ -1,5 +1,6 @@
 {% if data.widget.displaySorting %}
-  <select class="default-select ideas-sort-select openstad-ajax-refresh-input" name="sort" data-reset-pagination="1">
+  <label for="resource-sort-filter" class="sr-only">Sorteren op: </label>
+  <select class="default-select ideas-sort-select openstad-ajax-refresh-input" id="resource-sort-filter" name="sort" data-reset-pagination="1">
     {% for selectedSorting in data.widget.selectedSorting %}
     <option value="{{selectedSorting.value}}" {{ 'selected' if data.query.sort === selectedSorting.value or (not data.query.sort and data.widget.defaultSort === selectedSorting.value) }} >
       Sorteren: {{ __(selectedSorting.label) }}

--- a/packages/cms/lib/modules/resource-overview-widgets/views/includes/controls/theme.html
+++ b/packages/cms/lib/modules/resource-overview-widgets/views/includes/controls/theme.html
@@ -1,5 +1,6 @@
 {% if data.widget.displayThemeFilter %}
-<select class="default-select openstad-ajax-refresh-input" name="theme" data-reset-pagination="1">
+<label for="resource-theme-filter" class="sr-only">Selecteer een thema: </label>
+<select class="default-select openstad-ajax-refresh-input" id="resource-theme-filter" name="theme" data-reset-pagination="1">
   <option value="">Alle thema's</option>
   {% for theme in data.widget.themes %}
   <option value="{{theme.value}}" {% if theme.value === data.query.theme %} selected {% endif %}>{{theme.value}}</option>

--- a/packages/cms/lib/modules/resource-overview-widgets/views/includes/filters.html
+++ b/packages/cms/lib/modules/resource-overview-widgets/views/includes/filters.html
@@ -9,6 +9,7 @@
     {{'resource-filters-with-sorting' if data.widget.displaySorting}}
     {{'resource-filters-with-area'    if data.widget.displayAreaFilter}}
   "
+  autocomplete="off"
 >
   <div class="resource-filter-row">
     {% include 'includes/controls/search.html' %}

--- a/packages/cms/lib/modules/resource-representation-widgets/public/css/main.less
+++ b/packages/cms/lib/modules/resource-representation-widgets/public/css/main.less
@@ -227,7 +227,7 @@
 						}
 					}
 					&.selected[value="no"] {
-						background-color: #ea1d25;
+						background-color: @amsterdam-red;
 						&:disabled, &:disabled:hover {
   						background-color: #bebebe;
 							color: white;
@@ -250,7 +250,7 @@
 						&.selected[value="no"] {
 							&:disabled {
 								opacity: 0.5;
-								background-color: #ea1d25;
+								background-color: @amsterdam-red;
 							}
 						}
 					}

--- a/packages/cms/lib/modules/resource-representation-widgets/views/display/idea-page.html
+++ b/packages/cms/lib/modules/resource-representation-widgets/views/display/idea-page.html
@@ -114,7 +114,11 @@
 
 	          {% if data.widget.siteConfig.minimumYesVotes and data.widget.hideVotes !== true %}
 						<div class="ideaProgress">
-							<div class="progress"><div class="bar {{idea.status}}" style="width: {{idea.progress}}%;"></div></div>
+							<div class="progress">
+								<div class="bar {{idea.status}}" style="width: {{idea.progress}}%;">
+									<span class="sr-only">Aantal stemmen voor het plan: {{idea.yes}} van de {{data.global.siteConfig.ideas.minimumYesVotes}}.</span>
+								</div>
+							</div>
 						</div>
 	          {% endif %}
 						{% if data.widget.hideStatus !== true %}

--- a/packages/cms/lib/modules/submissions-widgets/public/css/gridder-implementation.less
+++ b/packages/cms/lib/modules/submissions-widgets/public/css/gridder-implementation.less
@@ -29,7 +29,7 @@
 @amsterdam-navyblue-hover: #003066;
 @amsterdam-skyblue: #2b9ad6;
 @amsterdam-lightgreen: #bdd131;
-@amsterdam-red: #ea1d25;
+@amsterdam-red: #EC0000;
 
 body {
 .gridder {

--- a/packages/cms/views/layout.html
+++ b/packages/cms/views/layout.html
@@ -224,7 +224,7 @@ header-side-container{% if data.idea %}
 
   <nav id="navbar" class="navbar navbar-static-top">
     <div class="container">
-      <button type="button" class="navbar-toggle visibility-toggle body-backdrop-toggle" data-target=".navbar-menu">
+      <button type="button" class="navbar-toggle visibility-toggle body-backdrop-toggle" data-target=".navbar-menu" aria-expanded="false" aria-controls="mainMenu">
         <span class="sr-only">Toggle navigation</span>
         <div class="visible-active">
           <span class="icon-bar"></span>
@@ -236,34 +236,6 @@ header-side-container{% if data.idea %}
           <img src="/modules/openstad-assets/img/close-icon.svg" width="14" />
         </div>
       </button>
-      {% if data.global.displayMyAcount %}
-      <a href="#" class="account-menu-toggle visibility-toggle body-backdrop-toggle" data-target=".account-menu">
-        <div class="visible-active">
-          <img src="/modules/openstad-assets/img/avatar.svg" />
-        </div>
-        <div class="hidden-active">
-          <img src="/modules/openstad-assets/img/close-icon.svg" width="14" />
-        </div>
-      </a>
-      <div class="account-menu toggle-menu">
-        <nav  class="" role="navigation">
-          <div>
-            {% if data.loggedIn %}
-            <a href="{{data.siteUrl}}/oauth/logout" class="logout-button" role="button">
-              <!--  <span class="glyphicon glyphicon-log-out"></span> !-->
-              <img src="/modules/openstad-assets/img/avatar.svg" />
-              {{ __('Uitloggen') }}
-            </a>
-            {% else %}
-            <a href="{{data.siteUrl}}/oauth/login"  role="button">
-              <!-- <span class="glyphicon glyphicon-user"></span>  !-->
-              {{ __('Mijn account') }}
-            </a>
-            {% endif %}
-          </div>
-        </nav>
-      </div>
-      {% endif %}
       <div class="navbar-menu toggle-menu">
         <nav id="mainMenu" class="navbar navbar-expand-lg navbar-light " role="menubar">
           <ul class="nav navbar-left">
@@ -272,7 +244,7 @@ header-side-container{% if data.idea %}
             {% for item in data.global.mainMenuItems %}
             <li class="nav-item">
               <a
-              class="
+                      class="
               nav-link
               {% if item.mainMenuUrl === '\/' %}
               {% if data.currentPath === '\/' %}  active {% endif %}
@@ -281,9 +253,9 @@ header-side-container{% if data.idea %}
               {% endif %}
 
               "
-              href="{{ item.mainMenuUrl | safeRelativeUrl }}"
-              {% if item.mainMenuTarget %} target="_blank" {% endif %}
-              role="menuitem"
+                      href="{{ item.mainMenuUrl | safeRelativeUrl }}"
+                      {% if item.mainMenuTarget %} target="_blank" {% endif %}
+                      role="menuitem"
               >
                 {{ item.mainMenuLabel }}
               </a>
@@ -309,9 +281,9 @@ header-side-container{% if data.idea %}
             {% for topLink in data.global.topLinks.reverse() %}
             <li class="visible-xs">
               <a
-              href="{{topLink.url | safeRelativeUrl}}"
-              {% if link.targetBlank %} target="_blank" {% endif %}
-              class="nav-link "
+                      href="{{topLink.url | safeRelativeUrl}}"
+                      {% if link.targetBlank %} target="_blank" {% endif %}
+                      class="nav-link "
               >
                 <b> {{topLink.label}} </b>
               </a>
@@ -337,29 +309,57 @@ header-side-container{% if data.idea %}
             {% endif %}
           </ul>
 
-        	<nav id="subMenu" class="" role="navigation">
-        		<div>
+          <nav id="subMenu" class="" role="navigation">
+            <div>
               {% if data.global.ctaButtonText %}
               <a href="{{data.global.ctaButtonUrl | safeRelativeUrl}}" class="menu-cta-button" role="button">{{data.global.ctaButtonText}}</a>
               {% endif %}
               {% if data.global.displayMyAcount %}
-        			{% if data.loggedIn %}
-      				<a href="{{data.siteUrl}}/oauth/logout" class="account logout-button" role="button">
+              {% if data.loggedIn %}
+              <a href="{{data.siteUrl}}/oauth/logout" class="account logout-button" role="button">
                 <!-- <span class="glyphicon glyphicon-log-out"></span> !-->
                 {{ __('Uitloggen') }}
               </a>
-        			{% else %}
-      				<a href="{{data.siteUrl}}/oauth/login" class="account" role="button">
+              {% else %}
+              <a href="{{data.siteUrl}}/oauth/login" class="account" role="button">
                 <!-- <span class="glyphicon glyphicon-user"></span>  !-->
                 <img src="/modules/openstad-assets/img/avatar.svg" />
                 {{ __('Mijn account') }}
               </a>
-        			{% endif %}
               {% endif %}
-        		</div>
-        	</nav>
+              {% endif %}
+            </div>
+          </nav>
         </nav>
       </div>
+      {% if data.global.displayMyAcount %}
+      <a href="#" class="account-menu-toggle visibility-toggle body-backdrop-toggle" data-target=".account-menu" aria-expanded="false" aria-controls="accountMenu" role="button">
+        <div class="visible-active">
+          <img src="/modules/openstad-assets/img/avatar.svg" />
+        </div>
+        <div class="hidden-active">
+          <img src="/modules/openstad-assets/img/close-icon.svg" width="14" />
+        </div>
+      </a>
+      <div id="accountMenu" class="account-menu toggle-menu">
+        <nav  class="" role="navigation">
+          <div>
+            {% if data.loggedIn %}
+            <a href="{{data.siteUrl}}/oauth/logout" class="logout-button" role="button">
+              <!--  <span class="glyphicon glyphicon-log-out"></span> !-->
+              <img src="/modules/openstad-assets/img/avatar.svg" />
+              {{ __('Uitloggen') }}
+            </a>
+            {% else %}
+            <a href="{{data.siteUrl}}/oauth/login"  role="button">
+              <!-- <span class="glyphicon glyphicon-user"></span>  !-->
+              {{ __('Mijn account') }}
+            </a>
+            {% endif %}
+          </div>
+        </nav>
+      </div>
+      {% endif %}
     </div>
   </nav>
   {% endif %}

--- a/packages/cms/views/layout.html
+++ b/packages/cms/views/layout.html
@@ -194,6 +194,7 @@ header-side-container{% if data.idea %}
                   href="{{topLink.url | safeRelativeUrl}}"
                   {% if topLink.targetBlank %} target="_blank" {% endif %}
                   class="link-caret--black"
+                  {% if data.currentPath.startsWith(topLink.url) %}  aria-current="page" {% endif %}
                   >
                     {{topLink.label}}
                   </a>
@@ -256,6 +257,12 @@ header-side-container{% if data.idea %}
                       href="{{ item.mainMenuUrl | safeRelativeUrl }}"
                       {% if item.mainMenuTarget %} target="_blank" {% endif %}
                       role="menuitem"
+
+                      {% if item.mainMenuUrl === '\/' %}
+              {% if data.currentPath === '\/' %}  aria-current="page" {% endif %}
+              {% else %}
+              {% if data.currentPath.startsWith(item.mainMenuUrl) %} aria-current="page" {% endif %}
+              {% endif %}
               >
                 {{ item.mainMenuLabel }}
               </a>
@@ -264,11 +271,15 @@ header-side-container{% if data.idea %}
 
             {% else %}
             <li class="nav-item">
-              <a href="{{ data.home._url  }}" class="nav-link {% if data.originalUrl === '/' %} active {% endif %}" role="menuitem">{{ data.home.title }}</a>
+              <a href="{{ data.home._url  }}" class="nav-link {% if data.originalUrl === '/' %} active {% endif %}" role="menuitem"
+                 {% if data.originalUrl === '/' %}  aria-current="page" {% endif %}>
+                {{ data.home.title }}
+              </a>
             </li>
             {% for tab in data.home._children %}
             <li class="nav-item">
-              <a class="nav-link {% if data.currentPath.startsWith(tab._url) %} active {% endif %}" href="{{ tab._url }}" role="menuitem">
+              <a class="nav-link {% if data.currentPath.startsWith(tab._url) %} active {% endif %}" href="{{ tab._url }}" role="menuitem"
+                 {% if data.currentPath.startsWith(tab._url) %}  aria-current="page" {% endif %}>
                 {{ tab.title }}
               </a>
             </li>
@@ -312,7 +323,10 @@ header-side-container{% if data.idea %}
           <nav id="subMenu" class="" role="navigation">
             <div>
               {% if data.global.ctaButtonText %}
-              <a href="{{data.global.ctaButtonUrl | safeRelativeUrl}}" class="menu-cta-button" role="button">{{data.global.ctaButtonText}}</a>
+              <a href="{{data.global.ctaButtonUrl | safeRelativeUrl}}" class="menu-cta-button" role="button"
+                 {% if data.currentPath.startsWith(data.global.ctaButtonUrl) %}  aria-current="page" {% endif %}>
+                {{data.global.ctaButtonText}}
+              </a>
               {% endif %}
               {% if data.global.displayMyAcount %}
               {% if data.loggedIn %}


### PR DESCRIPTION
This commit adds the first batch of fixes for the accessibility retest:

- Add an accessible location field to the resource form
- Add screen reader labels to the filter input fields above the resource overview. Also an autocomplete attribute was added to the resource overview filter.
- Add a focus indicator to the thumbs up button inside an argument form
- Update the red amsterdam variable and changed old hex codes to the @amsterdam-red variable.
    - This color did not pass the WCAG contrast check
    - The delete button next to the participator budget theme filter now has a more visual color when the filter is active.
- Change the html order of the menu so that the focus goes directly into the submenu.
- Add the aria-current attribute to the current page menu item
- Add a screen reader only text to the voting progress bar at a single idea page and in the ideas in the resource overview.
- Add a focus psuedo element to the delete button in the participatory budgeting widget. Now the delete button is also visible when focused, instead of just on hover.
- Change the javascript so that the message for the characters in a form is accessible and audible.