### PR TITLE
Choices guide result counter stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+* Add choices guide option to counter widget
+
 ## v0.21.0
 * Add global option to disable newsletter captcha
 * Add options to hide votes / status / last name in resource-representation-widgets

--- a/packages/cms/lib/modules/counter-widgets/index.js
+++ b/packages/cms/lib/modules/counter-widgets/index.js
@@ -55,6 +55,13 @@ module.exports = {
             'argumentIdeaId', 'argumentSentiment'
           ]
         },
+        {
+          label: 'Choices guide count',
+          value: 'choicesGuide',
+          showFields: [
+            'choicesGuideId'
+          ]
+        },
       ]
     },
     {
@@ -108,6 +115,11 @@ module.exports = {
           value: '',
         },
       ]
+    },
+    {
+      name: 'choicesGuideId',
+      label: 'Choices guide id',
+      type: 'string'
     },
     styleSchema.definition('containerStyles', 'Styles for the container')
   ],
@@ -200,6 +212,11 @@ module.exports = {
           if (widget.argumentIdeaId) queryparams.push( "ideaId=" + widget.argumentIdeaId );
           if (widget.argumentSentiment) queryparams.push( "sentiment=" + widget.argumentSentiment );
           if (queryparams) widget.statsUrl += '?' + queryparams.join('&');
+          break;
+
+        case 'choicesGuide':
+          count = 0;
+          widget.statsUrl = `/api/site/${widget.siteId}/choicesguide/${widget.choicesGuideId}/result?count=true`
           break;
 
         default:

--- a/packages/cms/lib/modules/counter-widgets/index.js
+++ b/packages/cms/lib/modules/counter-widgets/index.js
@@ -216,7 +216,10 @@ module.exports = {
 
         case 'choicesGuide':
           count = 0;
-          widget.statsUrl = `/api/site/${widget.siteId}/choicesguide/${widget.choicesGuideId}/result?count=true`
+          widget.statsUrl = `/stats/site/${widget.siteId}/choicesguides/total`;
+          if (widget.choicesGuideId) {
+            widget.statsUrl += `?choicesGuideId=${widget.choicesGuideId}`;
+          }
           break;
 
         default:


### PR DESCRIPTION
- Add choices guide option to counter widget
- Make choicesGuideId optional
See API PR: https://github.com/Amsterdam/openstad-api/pull/197