### PR TITLE
participatory-budgeting-widgets: scroll to ideas list

### DIFF
--- a/packages/cms/lib/modules/participatory-budgeting-widgets/public/js/ideas-lister.js
+++ b/packages/cms/lib/modules/participatory-budgeting-widgets/public/js/ideas-lister.js
@@ -96,7 +96,9 @@ function ideaListClick(event) {
 }
 
 function scrollToIdeas() {
-  scrollToResolver(document.getElementById('ideas-anchor'));
+	// Find first matching element for ideas list
+    var el = document.querySelectorAll('#ideasList, #ideas-anchor, #ideaList').item(0);
+    scrollToResolver(el);
 }
 
 function scrollToResolver(elem) {


### PR DESCRIPTION
This fixes the scroll to ideas list not working for the participatory budgeting widget. By selecting multiple possible matches and selecting the first match to scroll to the ideas list.