### PR TITLE
fix: location-widgets had missing mapConfig

### DIFF
--- a/packages/cms/lib/modules/location-widgets/index.js
+++ b/packages/cms/lib/modules/location-widgets/index.js
@@ -16,6 +16,8 @@ module.exports = {
   construct: function(self, options) {
      let classIdeaId;
 
+    // Add mapConfig to playerData so it can be used in javascript
+    options.playerData = ['mapConfig']
 
      const superPushAssets = self.pushAssets;
      self.pushAssets = function () {


### PR DESCRIPTION
When a user was not logged in the widget data gets removed. By setting a list of allowed widget data (`playerData`) this data gets populate and is accessible inside the widget code (eg. `playAfterlibsLoaded()`).