### PR TITLE
Block api calls to other sites - related ticket https://trello.com/c/…

### DIFF
--- a/packages/cms/lib/modules/api-proxy/index.js
+++ b/packages/cms/lib/modules/api-proxy/index.js
@@ -21,6 +21,15 @@ module.exports = {
             pathRewrite: {['^' + apiPath]: '/api'},
             onProxyReq: (proxyReq, req, res) => {
 
+                const siteId = req.data.global.siteId;
+                let path = req.path;
+                let match = path.match(/\/api\/site\/(\d+)\//);
+                if (match && match[1] != siteId) {
+                    return res.status(403).json({
+                        'message' : self.apos.i18n.__('The api call is for another site')
+                    });
+                }
+            
                 /**
                  * Validate the request with captcha if send by a form
                  */


### PR DESCRIPTION
In de laatste pentest werden we gewezen (5.2 Onvoldoende segmentatie Nginx Vhosts) op een slordigheid die toe staat om api calls te doen op een andere site dan de site die je bezoekt. Dat moet dichtgezet.