### PR TITLE
fix: use `background-image` instead of `background` because it overrides `background-position` property

### DIFF
--- a/packages/cms/lib/modules/openstad-assets/public/css/links.less
+++ b/packages/cms/lib/modules/openstad-assets/public/css/links.less
@@ -14,7 +14,7 @@
 
 .link-caret {
   &--blue {
-    background: url(/modules/openstad-assets/img/arrow-right-blue.svg);
+    background-image: url(/modules/openstad-assets/img/arrow-right-blue.svg);
     background-repeat: no-repeat;
 
     &:hover {


### PR DESCRIPTION
Related to #308 

![Screenshot 2022-02-23 at 12 48 16](https://user-images.githubusercontent.com/1849831/155313762-051c4bcf-4da4-4722-9699-c61c41b0077a.png)

![Screenshot 2022-02-23 at 12 48 02](https://user-images.githubusercontent.com/1849831/155313768-3abd57b0-822d-40e1-921c-8b82d1dfa52a.png)

