### PR TITLE
Use direct links to fetch images in filepond

### DIFF
--- a/packages/cms/lib/modules/choices-guide-widgets/lib/create-config.js
+++ b/packages/cms/lib/modules/choices-guide-widgets/lib/create-config.js
@@ -34,7 +34,7 @@ module.exports = function createConfig(widget, data, jwt, apiUrl, loginUrl) {
     image: {
       server: {
 				process: '/image',
-				fetch: '/image',
+				fetch: process.env.IMAGE_API_URL,
         srcExtension: '/:/rs=w:[[width]],h:[[height]];cp=w:[[width]],h:[[height]]',
       },
       aspectRatio: widget.imageAspectRatio || '16x9',

--- a/packages/cms/lib/modules/ideas-on-map-widgets/lib/create-config.js
+++ b/packages/cms/lib/modules/ideas-on-map-widgets/lib/create-config.js
@@ -101,7 +101,7 @@ module.exports = function createConfig(widget, data, jwt, apiUrl, loginUrl, imag
     image: {
       server: {
 				process: imageProxy,
-				fetch: imageProxy,
+				fetch: process.env.IMAGE_API_URL,
         srcExtension: '/:/rs=w:[[width]],h:[[height]];cp=w:[[width]],h:[[height]]',
       },
       aspectRatio: widget.imageAspectRatio || '16x9',


### PR DESCRIPTION
# Description

The frontend has an image proxy for authorized image uploading. Currently this proxy is also used for image downloading using filepond, and this should not be so.

## Type of change

Code improvement

## Documentation

## Tests

Only locally

