### PR TITLE
Add userId

### DIFF
--- a/packages/cms/lib/modules/ideas-on-map-widgets/lib/create-config.js
+++ b/packages/cms/lib/modules/ideas-on-map-widgets/lib/create-config.js
@@ -39,7 +39,7 @@ module.exports = function createConfig(widget, data, jwt, apiUrl, loginUrl, imag
   try {
     mapLocationIcon = JSON.parse(mapLocationIcon);
   } catch (err) {}
-
+  
   let config = {
     // data.isAdmin
     divId: 'ideeen-op-de-kaart',
@@ -50,6 +50,7 @@ module.exports = function createConfig(widget, data, jwt, apiUrl, loginUrl, imag
       isUserLoggedIn: data.loggedIn,
     },
     user: {
+      id:  data.openstadUser && data.openstadUser.id,
       role:  data.openstadUser && data.openstadUser.role,
       displayName:  data.openstadUser && data.openstadUser.displayName,
     },


### PR DESCRIPTION
# Description

In the ideas-on-map widget a user is added but the user's id is missing. The user's id should be available in the widget.

## Type of change

I would call this a bug fix