### PR TITLE
Update fields.js bugfix 'no sentiment'

### DIFF
--- a/packages/cms/lib/modules/arguments-block-widgets/lib/fields.js
+++ b/packages/cms/lib/modules/arguments-block-widgets/lib/fields.js
@@ -19,7 +19,7 @@ module.exports = [
         },
         {
           label: 'No sentiment',
-          value: '',
+          value: 'no sentiment',
         },
       ]
     },


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description
Made it possible for arguments with 'no sentiment' to be added to the databases
REQUIRES https://github.com/openstad/openstad-api/pull/244 to work, if this one is not available then the API will reject the value send by this fix.

## Issue reference

Fixes # (issue)
Belongs to bug https://trello.com/c/URra6zQt

## Type of change
bugfix (wrong branchname, by accident)

## Tests
- Login as admin on a site of your choosing.
- Go to 'plannen'
- Create a plan to use if no plans are available
- go to the ' edit arguments' section and change one of the boxes to use to the 'no sentiment' option.

## Branch
devel

