### PR TITLE
feat: publish docker image every commit

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -3,6 +3,8 @@
 name: Build and Publish Version Tags
 on:
   push:
+    branches:
+      - '**'
     tags:
       - "v*"
 
@@ -22,7 +24,9 @@ env:
   APP_URL: "http://localhost:4444"
   APOS_BUNDLE: assets
   APOS_MINIFY: 1
+  APOS_WORKFLOW: ON
   NODE_ENV: production
+  IMAGE: ${{ secrets.DOCKER_IMAGE || 'openstad/frontend' }}
 
 jobs:
   build:
@@ -34,18 +38,22 @@ jobs:
     steps:
       - name: Git checkout
         uses: actions/checkout@v2
+      
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.IMAGE }}
+          tags: |
+            # branch event
+            type=ref,event=branch,suffix=-{{sha}}
+            # tag event
+            type=ref,event=tag
 
       # setup Docker buld action
-      - name: Docker setup
-        uses: docker/setup-buildx-action@v1
+      - name: Set up Docker Buildx
         id: buildx
-        with:
-          install: true
-
-      - name: Extract branch name
-        shell: bash
-        run: echo "##[set-output name=branch;]$(echo ${GITHUB_REF#refs/heads/})"
-        id: extract_branch
+        uses: docker/setup-buildx-action@v1
 
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v1
@@ -57,16 +65,7 @@ jobs:
         with:
           mongodb-version: 4.2
 
-      - name: Get the version
-        id: get_version
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-
-      - name: Set CURRENT_BRANCH
-        run: echo "CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_ENV
-
       - run: mongo default --eval 'db.createUser({user:"travis",pwd:"test",roles:["readWrite"]});'
-
-      - run: echo '${{ steps.extract_branch.outputs.branch }}' > branch.txt
 
       - run: npm install --production
 
@@ -75,11 +74,8 @@ jobs:
 
       - run: mkdir assets
 
-      - run: NODE_ENV=production APOS_MINIFY=1 APOS_WORKFLOW=ON APOS_BUNDLE=assets node apostrophe.js apostrophe:generation  --create-bundle assets
-
-      #   - name: tag number
-      #        run : echo ${{ github.event.release.tag_name }}
-
+      - name: Bundle assets
+        run: node apostrophe.js apostrophe:generation  --create-bundle assets
 
       - name: Login to DockerHub
         uses: docker/login-action@v1
@@ -87,8 +83,27 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build
-        run: docker buildx build . -t openstad/frontend:${{ steps.get_version.outputs.VERSION }} -o type=registry
+      - name: Build image and push to Docker Hub and GitHub Container Registry
+        id: docker_build
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+
+      - name: Comment build info in commit
+        uses: actions/github-script@0.9.0
+        env:
+          STDOUT: "Published new image: `${{ fromJson(steps.docker_build.outputs.metadata)['image.name'] }}`"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            github.repos.createCommitComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: context.sha,
+              body: process.env.STDOUT
+            })
 
       - name: Image digest
-        run: echo ${{ steps.docker_build.outputs.digest }}
+        run: echo "${{ steps.docker_build.outputs.metadata }}"


### PR DESCRIPTION
# Description

This PR adds new docker builds on push. Every push gets build by Github CI and tags the build with the branch name and commit sha. For example: `feat-create-docker-container-on-push-07a8c10`. This allows you to quickly test new features. On successful build this also creates a comment with the released image.

## Type of change

Feature

## Documentation

None

## Tests

Tested via GitHub workflow.

## Branch

`master`

## Related

https://github.com/openstad/openstad-api/pull/246