### PR TITLE
Added check if every page should be translated on entry, fixed full w…

### DIFF
--- a/packages/cms/lib/modules/openstad-assets/public/css/helpers.less
+++ b/packages/cms/lib/modules/openstad-assets/public/css/helpers.less
@@ -6,6 +6,10 @@
   text-align: right;
 }
 
+.initial-width {
+  width: initial !important;
+}
+
 .stretch {
   width: 100%;
 }

--- a/packages/cms/views/layout.html
+++ b/packages/cms/views/layout.html
@@ -80,7 +80,7 @@
  var authServerLogoutUrl = '{{apos.settings.getOption('apiLogoutUrl')}}';
  var openstadUserRole = '{{data.openstadUser.role}}';
  var hasModeratorRights = {{'true' if data.hasModeratorRights else  'false'}};
-
+ var shouldTranslateOnEveryPage = '{{data.global.shouldAutoTranslate}}' === 'true';
  var currentPath = '{{data.currentPath}}';
  var siteUrl = '{{data.siteUrl}}';
  var currentPathname = '{{data.currentPathname}}';
@@ -426,7 +426,7 @@
   <div class="body-background" style="display: none;"></div>
 
 
-  <div id="openstad-toast" class="toast-container">
+  <div id="openstad-toast" class="toast-container initial-width">
     
   </div>
 


### PR DESCRIPTION
…idth bug on plannen/[detail]

<!-- Please fill in the appropriate information -->

# Description
Added a way for the openstad global widget to know if on a page entered it should try and translate the page, added acknowledge variable to not receive a toast on every page enter if you are logged in as admin, editor or moderator, fixed fullwidth bug on plannen/[detail]
Please include
- a summary of the changes
- relevant motivation and context
- a list of any dependencies that are required for this change

## Issue reference

Fixes # (issue)

## Type of change

Is it a new feature, bug fix, code improvement, etc.  
If it is a breaking change what needs to be done to fix that

## Documentation

Is the documentation updated, maybe a link

## Tests

(How) has the change been tested

## Branch

If the branch to merge to is not development

