### PR TITLE
Fix merging of configs in release components

### DIFF
--- a/packages/cms/lib/modules/arguments-block-widgets/index.js
+++ b/packages/cms/lib/modules/arguments-block-widgets/index.js
@@ -1,5 +1,3 @@
-const merge = require('merge');
-
 const { fields, arrangeFields } = require('./lib/fields');
 const createConfig = require('./lib/create-config');
 
@@ -32,7 +30,7 @@ module.exports = {
           widget: widget,
           data: req.data,
         });
-			  widget.config = merge.recursive(config, widget.config);
+			  widget.config = config;
         widget.divId = widget.config.divId;
       });
       

--- a/packages/cms/lib/modules/choices-guide-result-widgets/index.js
+++ b/packages/cms/lib/modules/choices-guide-result-widgets/index.js
@@ -1,5 +1,3 @@
-const merge = require('merge');
-
 const { fields, arrangeFields } = require('./lib/fields');
 const createConfig = require('./lib/create-config');
 
@@ -46,7 +44,7 @@ module.exports = {
           data: req.data,
           logoutUrl: apiUrl + '/oauth/logout',
         });
-			  widget.config = merge.recursive(config, widget.config);
+			  widget.config = config;
         widget.divId = widget.config.divId;
       });
 

--- a/packages/cms/lib/modules/choices-guide-widgets/index.js
+++ b/packages/cms/lib/modules/choices-guide-widgets/index.js
@@ -1,5 +1,3 @@
-const merge = require('merge');
-
 const { fields, arrangeFields } = require('./lib/fields');
 const createConfig = require('./lib/create-config');
 
@@ -44,7 +42,7 @@ module.exports = {
           widget: widget,
           data: req.data,
         });
-			  widget.config = merge.recursive(config, widget.config);
+			  widget.config = config;
         widget.divId = widget.config.divId;
       });
 

--- a/packages/cms/lib/modules/ideas-on-map-widgets/index.js
+++ b/packages/cms/lib/modules/ideas-on-map-widgets/index.js
@@ -1,5 +1,3 @@
-const merge = require('merge');
-
 const { fields, arrangeFields } = require('./lib/fields');
 const createConfig = require('./lib/create-config');
 
@@ -31,7 +29,7 @@ module.exports = {
           data: req.data,
           apos: self.apos,
         });
-			  widget.config = merge.recursive(config, widget.config);
+			  widget.config = config;
         widget.divId = widget.config.divId;
       });
       

--- a/packages/cms/lib/modules/previous-next-button-block-widgets/index.js
+++ b/packages/cms/lib/modules/previous-next-button-block-widgets/index.js
@@ -1,5 +1,3 @@
-const merge = require('merge');
-
 const { fields, arrangeFields } = require('./lib/fields');
 const createConfig = require('./lib/create-config');
 
@@ -29,7 +27,7 @@ module.exports = {
           widget: widget,
           data: req.data,
         });
-			  widget.config = merge.recursive(config, widget.config);
+			  widget.config = config;
         widget.divId = widget.config.divId;
 			});
 


### PR DESCRIPTION
# Description

The use of OpenStad components has been refactored for this release. One of these changes is that configuration of components is done through the widget and through it's parent. Both config re merged.

I am not quite sure why, but somehow this leads to strange config values being added. What I did find is that more configuration is merged than should have been. This is now removed, and that seems to fix the problem.

## Type of change

Bugfix


