### PR TITLE
Replaced sessionStorage with localstorage so translating works after …

### DIFF
--- a/packages/cms/lib/modules/openstad-global/public/js/always.js
+++ b/packages/cms/lib/modules/openstad-global/public/js/always.js
@@ -1,6 +1,6 @@
 apos.on('ready', function () {
     var nodes = [];
-    var selectedLanguage = sessionStorage.getItem("targetLanguageCode");
+    var selectedLanguage = localStorage.getItem("targetLanguageCode");
 
     /** 
      * The translate widget if set on the page will trigger an onchange event when it has been loaded

--- a/packages/cms/lib/modules/translation-widgets/public/js/always.js
+++ b/packages/cms/lib/modules/translation-widgets/public/js/always.js
@@ -26,7 +26,7 @@ apos.define('translation-widgets', {
 
         function saveLanguagePreference(targetLanguageCode) {
             try{
-                sessionStorage.setItem("targetLanguageCode", targetLanguageCode);
+                localStorage.setItem("targetLanguageCode", targetLanguageCode);
             } catch(quotaExceededError) {
                 console.log("Could not save the language preference");
             }
@@ -98,7 +98,7 @@ apos.on('ready', function() {
     var select = document.querySelector('.translation-widget-select');
     var isNormalUser = !hasModeratorRights; // references global var specified in layout.js
     if(isNormalUser) {
-        setSelectedLanguage(sessionStorage.getItem('targetLanguageCode'));
+        setSelectedLanguage(localStorage.getItem('targetLanguageCode'));
     } else if(select) {
         select.setAttribute('disabled', true);
     }


### PR DESCRIPTION
…login in, cannot translate acknowledge remains the same with sessionstorage

<!-- Please fill in the appropriate information -->

# Description
given that the language before logging in is set to something else than nl, after login the translate widget would not translate because the key targetLanguageCode was remembered in a sessionstorage which only accounts for the current tab session. By using a localstorage the key gets shared by all tabs