### PR TITLE
Fix issue with tabs ans scrolling

### DIFF
--- a/packages/cms/lib/modules/section-widgets/public/js/main.js
+++ b/packages/cms/lib/modules/section-widgets/public/js/main.js
@@ -10,10 +10,7 @@ apos.define('section-widgets', {
 
 function initTabs ($parent) {
 
-  console.log("init tabs fout");
-  
   var $tabContainers = $parent.find('.tab-container');
-
 
   if ($tabContainers.length > 0) {
     $tabContainers.hide();
@@ -40,6 +37,6 @@ function setContainerForHash($parent) {
     var selector = 'a[href*="'+hash+'"]';
     // console.log('selector', selector, $parent.find(selector))
     $parent.find(selector).addClass('active')
-    $(hash).show();
+    $(hash+'-container').show();
   }
 }

--- a/packages/cms/lib/modules/section-widgets/views/types/tabs.html
+++ b/packages/cms/lib/modules/section-widgets/views/types/tabs.html
@@ -13,7 +13,7 @@
             </ul>
             {% for tab in data.widget.tabs %}
             {% if tab.areaName %}
-            <div id="tab-{{loop.index}}" class="tab-container">
+            <div id="tab-{{loop.index}}-container" class="tab-container">
                 {{
                     apos.area(data.widget, tab.areaName, {
                         widgets: data.widget.contentWidgets


### PR DESCRIPTION
When using a tabs section the page initializes by adding `#tab-1` to the url. In chrome this results in a scroll to the tabs section.

This fix uses a different ID for the tabs section by which the scroll action should be void.