### PR TITLE
Aloow for multiple tabs sections on a page

### DIFF
--- a/packages/cms/lib/modules/section-widgets/index.js
+++ b/packages/cms/lib/modules/section-widgets/index.js
@@ -283,6 +283,11 @@ module.exports = {
         },
       ]
     },
+    {
+      name: 'sectionName',
+      type: 'string',
+      label: 'Name',
+    },
   ],
 
 
@@ -311,7 +316,7 @@ module.exports = {
       {
         name: 'tabs',
         label: 'Tabs',
-        fields: ['tabs']
+        fields: ['sectionName', 'tabs']
       }
     ]);
 

--- a/packages/cms/lib/modules/section-widgets/public/js/main.js
+++ b/packages/cms/lib/modules/section-widgets/public/js/main.js
@@ -7,39 +7,51 @@ apos.define('section-widgets', {
   }
 });
 
+function findMyHash($parent) {
+
+  let hashes = window.location.hash && window.location.hash.match(/#tab-\d+(?:-[^#]+)?/g);
+
+  for (let hash of hashes) {
+    let match = hash.match(/#tab-(\d+)(?:-([^#]+))?/);
+    if (match[2] && $parent.find(`.section-tabs-${match[2]}`).length) return hash;
+  }
+
+  for (let hash of hashes) {
+    let match = hash.match(/#tab-(\d+)(?:-([^#]+))?/);
+    if (!match[2]) return hash;
+  }
+
+}
 
 function initTabs ($parent) {
 
-  console.log("init tabs fout");
-  
   var $tabContainers = $parent.find('.tab-container');
-
 
   if ($tabContainers.length > 0) {
     $tabContainers.hide();
 
-    $(window).on( 'hashchange', function( e ) {
-      setContainerForHash($parent)
+    $(window).on('hashchange', function( e ) {
+      let hash = findMyHash($parent);
+      if (hash) setContainerForHash($parent, hash)
     });
 
-    if (!window.location.hash || window.location.hash.length === 0) {
+    let hash = findMyHash($parent);
+    if (!hash) {
       $parent.find('.nav-link').first().get(0).click();
     } else {
-      setContainerForHash($parent);
+      setContainerForHash($parent, hash);
     }
   }
 }
 
-
-function setContainerForHash($parent) {
-  var hash = window.location.hash;
-
-  if (hash.startsWith('#tab-')) {
-    $parent.find('.tab-container').hide();
-    $parent.find('.nav-link').removeClass('active')
-    var selector = 'a[href*="'+hash+'"]';
-    // console.log('selector', selector, $parent.find(selector))
-    $parent.find(selector).addClass('active')
-    $(hash).show();
-  }
+function setContainerForHash($parent, hash) {
+  let match = hash.match(/#tab-(\d+)(?:-([^#]+))?/);
+  let tabnumber = match[1];
+  let sectionName = match[1][2] || $parent[0].innerHTML.match(/class="section-tabs section-tabs-([^"]*)"/)[1];
+  hash = '#tab-' + tabnumber + (sectionName ? '-'+sectionName: '');
+  $parent.find('.tab-container').hide();
+  $parent.find('.nav-link').removeClass('active')
+  let selector = 'a[href*="'+'#tab-'+tabnumber+'-'+sectionName+'"]';
+  $parent.find(selector).addClass('active')
+  $parent.find('#tab-'+tabnumber+'-container').show();
 }

--- a/packages/cms/lib/modules/section-widgets/views/types/tabs.html
+++ b/packages/cms/lib/modules/section-widgets/views/types/tabs.html
@@ -1,27 +1,27 @@
 <style>
-    {{data.widget.formattedContainerStyles}}
+ {{data.widget.formattedContainerStyles}}
 </style>
-<div id="{{data.widget.containerId}}" class="section-tabs">
-    <div class="row">
-        <div class="col-xs-12">
-            <ul class="nav nav-tabs">
-            {% for tab in data.widget.tabs %}
-                <li class="nav-item">
-                    <a class="nav-link" href="#tab-{{loop.index}}" tabindex="{{loop.index + 1}}"> {{tab.title}} </a>
-                </li>
-            {% endfor %}
-            </ul>
-            {% for tab in data.widget.tabs %}
-            {% if tab.areaName %}
-            <div id="tab-{{loop.index}}" class="tab-container">
-                {{
-                    apos.area(data.widget, tab.areaName, {
-                        widgets: data.widget.contentWidgets
-                    })
-                }}
-            </div>
-            {% endif %}
-            {% endfor %}
-        </div>
+<div id="{{data.widget.containerId}}" class="section-tabs section-tabs-{{data.widget.sectionName}}">
+  <div class="row">
+    <div class="col-xs-12">
+      <ul class="nav nav-tabs">
+        {% for tab in data.widget.tabs %}
+        <li class="nav-item">
+          <a class="nav-link" href="#tab-{{loop.index}}-{{data.widget.sectionName}}" tabindex="{{loop.index + 1}}"> {{tab.title}} </a>
+        </li>
+        {% endfor %}
+      </ul>
+      {% for tab in data.widget.tabs %}
+      {% if tab.areaName %}
+      <div id="tab-{{loop.index}}-container" class="tab-container">
+        {{
+        apos.area(data.widget, tab.areaName, {
+        widgets: data.widget.contentWidgets
+        })
+        }}
+      </div>
+      {% endif %}
+      {% endfor %}
     </div>
+  </div>
 </div>


### PR DESCRIPTION
# Multiple tab sections

Tab sections use the url hash to know which tab to show. This allows for urls that open the correct tab.

The implementation is too simple (`#tab-1`) which is a problem when multiple tab sections are placed on a page.

This change adds a name to a tab section, which makes it possible to read the correct hash for each tab.