### PR TITLE
fix: add fallback to tag when branch could not be fetched via git

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,8 @@ ENV S3_KEY=""
 ENV S3_SECRET=""
 ENV S3_BUCKET=""
 
+# CDN distribution tag used to fetch the latest version of the component libraries (openstad-components and react-admin)
+ENV CDN_DIST_TAG="latest"
 
 # Install all base dependencies.
 RUN apk add --no-cache --update openssl g++ make python3 musl-dev git bash

--- a/packages/cms/services/cdns.js
+++ b/packages/cms/services/cdns.js
@@ -19,17 +19,17 @@ exports.contructComponentsCdn = async function () {
       if (!version) {
         // fallback
         let packageFile =
-          fs.readFileSync(`${__dirname}/package.json`).toString() || '';
+          await fs.readFile(`${__dirname}/../package.json`).toString() || '';
         let match =
           packageFile &&
           packageFile.match(
             /"openstad-components":\s*"(?:[^"\d]*)((?:\d+\.)*\d+)"/
           );
-        version = (match && match[1]) || null;
+        version = (match && match[1]) || '';
       }
       openstadComponentsCdn = openstadComponentsCdn.replace(
-        '{version}',
-        version
+        '@{version}',
+        version ? `@${version}` : ''
       );
       console.log('Using cdn', openstadComponentsCdn);
     } catch (err) {
@@ -57,17 +57,17 @@ exports.contructReactAdminCdn = async function () {
       if (!version) {
         // fallback
         let packageFile =
-          fs.readFileSync(`${__dirname}/package.json`).toString() || '';
+          await fs.readFile(`${__dirname}/../package.json`).toString() || '';
         let match =
           packageFile &&
           packageFile.match(
             /"openstad-react-openstadComponentsCdn":\s*"(?:[^"\d]*)((?:\d+\.)*\d+)"/
           );
-        version = (match && match[1]) || null;
+        version = (match && match[1]) || '';
       }
       openstadReactAdminCdn = openstadReactAdminCdn.replace(
-        '{version}',
-        version
+        '@{version}',
+        version ? `@${version}` : ''
       );
       console.log('Using cdn', openstadReactAdminCdn);
     } catch (err) {

--- a/packages/cms/services/cdns.js
+++ b/packages/cms/services/cdns.js
@@ -1,79 +1,103 @@
-exports.contructComponentsCdn = async function() {
- 
+const fs = require('fs').promises;
+const util = require('util');
+const exec = util.promisify(require('child_process').exec);
+
+exports.contructComponentsCdn = async function () {
   // construct cdn urls
-  let openstadComponentsCdn = process.env.OPENSTAD_COMPONENTS_CDN || 'https://cdn.jsdelivr.net/npm/openstad-components@{version}/dist';
+  let openstadComponentsCdn =
+    process.env.OPENSTAD_COMPONENTS_CDN ||
+    'https://cdn.jsdelivr.net/npm/openstad-components@{version}/dist';
   if (openstadComponentsCdn.match('{version}')) {
-
     try {
-      const fs = require('fs').promises;
-      const util = require('util');
-      const exec = util.promisify(require('child_process').exec);
-      
-      let { stdout, stderr } = await exec('git rev-parse --abbrev-ref HEAD');
-      let branch = stdout && stdout.toString();
-      branch = branch.trim();
+      let tag = await getTag();
 
-      let tag = 'alpha';
-      if (branch == 'release') tag = 'beta';
-      if (branch == 'master') tag = 'latest';
-      
       // get current published version
       ({ stdout, stderr } = await exec('npm view --json openstad-components'));
       let info = stdout && stdout.toString();
-      info = JSON.parse(info)
+      info = JSON.parse(info);
       let version = info['dist-tags'][tag];
       if (!version) {
         // fallback
-        let packageFile = fs.readFileSync(`${__dirname}/package.json`).toString() || '';
-        let match = packageFile && packageFile.match(/"openstad-components":\s*"(?:[^"\d]*)((?:\d+\.)*\d+)"/);
-        version = match && match[1] || null;
+        let packageFile =
+          fs.readFileSync(`${__dirname}/package.json`).toString() || '';
+        let match =
+          packageFile &&
+          packageFile.match(
+            /"openstad-components":\s*"(?:[^"\d]*)((?:\d+\.)*\d+)"/
+          );
+        version = (match && match[1]) || null;
       }
-      openstadComponentsCdn = openstadComponentsCdn.replace('{version}', version);
+      openstadComponentsCdn = openstadComponentsCdn.replace(
+        '{version}',
+        version
+      );
       console.log('Using cdn', openstadComponentsCdn);
-    } catch (err) {console.log('Error constructing cdn url', err);}
-
+    } catch (err) {
+      console.log('Error constructing cdn url', err);
+    }
   }
 
   return openstadComponentsCdn;
-  
-}
+};
 
-exports.contructReactAdminCdn = async function() {
-
+exports.contructReactAdminCdn = async function () {
   // construct cdn urls
-  let openstadReactAdminCdn = process.env.OPENSTAD_REACT_ADMIN_CDN || 'https://cdn.jsdelivr.net/npm/openstad-react-admin@{version}/dist';
+  let openstadReactAdminCdn =
+    process.env.OPENSTAD_REACT_ADMIN_CDN ||
+    'https://cdn.jsdelivr.net/npm/openstad-react-admin@{version}/dist';
   if (openstadReactAdminCdn.match('{version}')) {
-
     try {
-      const fs = require('fs').promises;
-      const util = require('util');
-      const exec = util.promisify(require('child_process').exec);
-      
-      let { stdout, stderr } = await exec('git rev-parse --abbrev-ref HEAD');
-      let branch = stdout && stdout.toString();
-      branch = branch.trim();
+      let tag = await getTag();
 
-      let tag = 'alpha';
-      if (branch == 'release') tag = 'beta';
-      if (branch == 'master') tag = 'latest';
-      
       // get current published version
       ({ stdout, stderr } = await exec('npm view --json openstad-react-admin'));
       let info = stdout && stdout.toString();
-      info = JSON.parse(info)
+      info = JSON.parse(info);
       let version = info['dist-tags'][tag];
       if (!version) {
         // fallback
-        let packageFile = fs.readFileSync(`${__dirname}/package.json`).toString() || '';
-        let match = packageFile && packageFile.match(/"openstad-react-openstadComponentsCdn":\s*"(?:[^"\d]*)((?:\d+\.)*\d+)"/);
-        version = match && match[1] || null;
+        let packageFile =
+          fs.readFileSync(`${__dirname}/package.json`).toString() || '';
+        let match =
+          packageFile &&
+          packageFile.match(
+            /"openstad-react-openstadComponentsCdn":\s*"(?:[^"\d]*)((?:\d+\.)*\d+)"/
+          );
+        version = (match && match[1]) || null;
       }
-      openstadReactAdminCdn = openstadReactAdminCdn.replace('{version}', version);
+      openstadReactAdminCdn = openstadReactAdminCdn.replace(
+        '{version}',
+        version
+      );
       console.log('Using cdn', openstadReactAdminCdn);
-    } catch (err) {console.log('Error constructing cdn url', err);}
-
+    } catch (err) {
+      console.log('Error constructing cdn url', err);
+    }
   }
 
   return openstadReactAdminCdn;
-  
+};
+
+async function getTag() {
+  const util = require('util');
+  const exec = util.promisify(require('child_process').exec);
+
+  let branch = '';
+  let tag = 'alpha';
+
+  try {
+    let { stdout, stderr } = await exec('git rev-parse --abbrev-ref HEAD');
+    branch = stdout && stdout.toString().trim();
+  } catch (error) {
+    // As a fallback we check for the CDN_DIST_TAG env variable
+    if (process.env.CDN_DIST_TAG) {
+      tag = process.env.CDN_DIST_TAG;
+    }
+    console.warn(`Could not get branch via git; fallback to ${tag}`);
+  }
+
+  if (branch == 'release') tag = 'beta';
+  if (branch == 'master') tag = 'latest';
+
+  return tag;
 }


### PR DESCRIPTION
# Description

In the docker image we don't include any git history and this breaks the logic to dynamically parse a version for the used CDN endpoints. With this fix we introduce a new `CDN_DIST_TAG` environment variable which can be used to fetch dist-tagged versions from npm (eg. `alpha`, `beta`, `latest`) and will resolve it to a release version (eg. `latest` -> `1.0.3`, `alpha` -> `1.0.0-alpha.3`). This is helpful to circumvent caching issues by browsers.

## Type of change
Bug fix / improvement

## Tests

Use a docker image with the `CDN_DIST_TAG` environment variable. Your console should log that it can't use git to determine the branch and it will fallback to the given tag.

```
Could not get branch via git; fallback to alpha
Using cdn https://cdn.jsdelivr.net/npm/openstad-components@1.0.0-alpha.3/dist
```

Tested on openstad-ams-staging cluster

## Branch

Based of master/main, not development