### PR TITLE
Update translations

### DIFF
--- a/packages/cms/lib/modules/openstad-global/lib/api.js
+++ b/packages/cms/lib/modules/openstad-global/lib/api.js
@@ -47,13 +47,13 @@ module.exports = (self, options) => {
     let untranslatedElements = [];
     for (let text of content) {
       if (text.match(/[^\d\W]/)) {
-      let cacheKey = crypto.createHash('sha256').update(`${destinationLanguage}${text}`).digest('hex');
-      const translated = await collection.findOne({_id: cacheKey});
-      if (translated) {
-        result[text] = translated.translations;
-      } else {
-        untranslatedElements.push( text );
-      }
+        let cacheKey = crypto.createHash('sha256').update(`${destinationLanguage}${text}`).digest('hex');
+        const translated = await collection.findOne({_id: cacheKey});
+        if (translated) {
+          result[text] = translated.translations;
+        } else {
+          untranslatedElements.push( text );
+        }
       } else {
         // nothing to translate
         result[text] = { text };
@@ -93,12 +93,12 @@ module.exports = (self, options) => {
           );
         }
 
-    } catch(error) {
-      console.log(error);
-      return res.status(500).json({ error: 'Could not translate the page at this time' });
-    }
-
+      } catch(error) {
+        console.log(error);
+        return res.status(500).json({ error: 'Could not translate the page at this time' });
       }
+
+    }
 
     // transform the result object back to the original array
     result = content.map(text => result[text]);

--- a/packages/cms/lib/modules/openstad-global/lib/api.js
+++ b/packages/cms/lib/modules/openstad-global/lib/api.js
@@ -30,7 +30,7 @@ module.exports = (self, options) => {
     }
 
     // setup cache store
-    const collection = self.apos.db.collection("deepl-translations"); // is dit wel per site? want dat was wel het idee...
+    const collection = self.apos.db.collection("deepl-translations");
 
     // setup translate service
     let translator = null;

--- a/packages/cms/lib/modules/openstad-global/lib/api.js
+++ b/packages/cms/lib/modules/openstad-global/lib/api.js
@@ -19,67 +19,97 @@ module.exports = (self, options) => {
     const sourceLanguageCode = req.body.sourceLanguageCode;
     const destinationLanguage = req.body.targetLanguageCode;
 
-    const cacheKey = crypto.createHash('sha256').update(`${destinationLanguage}${origin}${JSON.stringify(content)}`).digest('hex');
-
-    if (!origin) {
-      return res.status(400).json({ error: 'Could not determine the page to translate' });
-    }
-
-    const collection = self.apos.db.collection("deepl-translations");
-    const result = await collection.findOne({_id: cacheKey});
-    if (result) {
-      console.log(`Receiving translations from cache for site ${origin}`);
-      return res.json(result.translations);
-    }
-
-    // content should always be a collection of dutch terms, translations to other languages are translated from dutch to (for example) english
     if (destinationLanguage === 'nl') {
       console.log(`Target language is dutch, not translating and responding with the dutch sentences received for site ${origin}`);
       return res.json(content);
     }
 
+    if (!deeplAuthKey) {
+      console.log(`ERROR: DeepL not configured`);
+      return res.status(500).json({ error: 'Could not translate the page at this time' });
+    }
 
-    if (deeplAuthKey) {
-      let translator = null;
+    // setup cache store
+    const collection = self.apos.db.collection("deepl-translations"); // is dit wel per site? want dat was wel het idee...
+
+    // setup translate service
+    let translator = null;
+    try {
+      translator = new deepl.Translator(deeplAuthKey, translatorConfig);
+    } catch (error) {
+      console.log({ error });
+    }
+    if (!translator) return res.status(500).json({ error: 'Could not translate the page at this time' });
+
+    // find translations and collect missing translations
+    let result = {};
+    let untranslatable = [];
+    let untranslatedElements = [];
+    for (let text of content) {
+      if (text.match(/[^\d\W]/)) {
+      let cacheKey = crypto.createHash('sha256').update(`${destinationLanguage}${text}`).digest('hex');
+      const translated = await collection.findOne({_id: cacheKey});
+      if (translated) {
+        result[text] = translated.translations;
+      } else {
+        untranslatedElements.push( text );
+      }
+      } else {
+        // nothing to translate
+        result[text] = { text };
+        untranslatable.push(text);
+      }
+
+    }
+
+    // now translate missing translations
+    if (untranslatedElements.length) {
+
+      const characterCount = untranslatedElements.map(word => word.length).reduce((total, a) => total + a, 0);
+      console.log(`Fetch missing translations from DeepL for site: ${origin} with charactersize of ${characterCount} and destination language ${destinationLanguage}`);
 
       try {
-        translator = new deepl.Translator(deeplAuthKey, translatorConfig);
-      } catch (error) {
-        console.log({ error });
-        return res.status(500).json({ error: 'Could not translate the page at this time' });
-      }
 
-      const characterCount = content.map(word => word.length).reduce((total, a) => total + a, 0);
-
-      if (translator) {
-        console.log(`No existing translations found, fetching translations from deepl for site: ${origin} with charactersize of ${characterCount} and destination language ${destinationLanguage}`)
-
-        translator.translateText(
-          content,
+        let translations = await translator.translateText(
+          untranslatedElements,
           sourceLanguageCode,
           destinationLanguage,
-        ).then(response => {
+        );
+
+        for (let i = 0; i < untranslatedElements.length; i++) {
+          let text = untranslatedElements[i];
+          let cacheKey = crypto.createHash('sha256').update(`${destinationLanguage}${text}`).digest('hex');
+          let translatedText = translations[i];
+          result[text] = translatedText;
           collection.findOneAndUpdate(
             {"_id": cacheKey},
-            { $set: { 
-                "origin": origin, 
-                "destinationLanguage": destinationLanguage,
-                "characters": characterCount,
-                "translations": response, 
-              },
+            { $set: {
+              "origin": origin,
+              "destinationLanguage": destinationLanguage,
+              "translations": translatedText,
             },
-            {upsert:true}
+            },
+            {upsert:true} // dit zal toch (bijna?) altijd een insert zijn, lijkt me...
           );
-          return res.json(response);
-        })
-          .catch(error => {
-            console.error({ error });
-            return res.status(500).json({ error: 'Error while translating the page' });
-          });
-      }
-    } else {
-      return res.status(400).json({ error: 'No valid key provided' });
+        }
+
+    } catch(error) {
+      console.log(error);
+      return res.status(500).json({ error: 'Could not translate the page at this time' });
     }
+
+      }
+
+    // transform the result object back to the original array
+    result = content.map(text => result[text]);
+
+    // temp: we need monitoring
+    console.log('Aantal elementen:', content.length);
+    console.log('Aantal niet te vertalen elementen:', untranslatable.length);
+    console.log('Aantal opnieuw vertaalde elementen:', untranslatedElements.length);
+
+    return res.json(result);
+
   }
 
   self.apos.app.post('/modules/openstad-global/translate', function (req, res) {


### PR DESCRIPTION
# Description

Currently translations are cached per page. This does not cache enough.

This change caches translation per bit of text. The number and size of requests to the translation service should be drastically reduced.
