### PR TITLE
Feature/extend arguments widget cp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Changelog
 
-## 1.0.0
+## UNRELEASED
 * Allow arguments-widget and arguments-form-widget to be used outside of a resource page by setting the idea ID in the options.
+
+## 1.0.0
 * Add submission to resource form with configurable confirmation settings
 * Update ideas-on-map config to work with react-leaflet
 * Refactor openstad-components widgets

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## 1.0.0
+* Allow arguments-widget and arguments-form-widget to be used outside of a resource page by setting the idea ID in the options.
 * Add submission to resource form with configurable confirmation settings
 * Update ideas-on-map config to work with react-leaflet
 * Refactor openstad-components widgets

--- a/packages/cms/lib/modules/arguments-form-widgets/index.js
+++ b/packages/cms/lib/modules/arguments-form-widgets/index.js
@@ -10,12 +10,11 @@ module.exports = {
   label: 'Arguments form old',
   adminOnly: true,
   addFields: [
-      /*
     {
       name: 'id',
       type: 'string',
       label: 'Idea ID (if empty it will try to fetch the ideaId from the URL)',
-    },*/
+    },
     {
       name: 'placeholder',
       type: 'string',

--- a/packages/cms/lib/modules/arguments-form-widgets/index.js
+++ b/packages/cms/lib/modules/arguments-form-widgets/index.js
@@ -12,7 +12,7 @@ module.exports = {
   addFields: [
       /*
     {
-      name: 'ideaId',
+      name: 'id',
       type: 'string',
       label: 'Idea ID (if empty it will try to fetch the ideaId from the URL)',
     },*/

--- a/packages/cms/lib/modules/arguments-form-widgets/views/widget.html
+++ b/packages/cms/lib/modules/arguments-form-widgets/views/widget.html
@@ -33,14 +33,13 @@
 				value="Verzenden"
 				data-modal-text="Log in om een argument te plaatsen, te reageren, of een argument te liken."
 			/>
-
 			<input
 				type="hidden"
 				name="ideaId"
-				{% if not data.widget.ideaId  %}
+				{% if not data.widget.id  %}
 				value="{{data.ideaId}}"
 				{% else %}
-				value="{{data.widget.ideaId}}"
+				value="{{data.widget.id}}"
 				{% endif %}
 			/>
 			<input type="hidden" name="_csrf" value="{{csrfToken}}">

--- a/packages/cms/lib/modules/arguments-form-widgets/views/widget.html
+++ b/packages/cms/lib/modules/arguments-form-widgets/views/widget.html
@@ -37,7 +37,7 @@
 				type="hidden"
 				name="ideaId"
 				{% if not data.widget.id  %}
-				value="{{data.ideaId}}"
+				value="{{data.widget.ideaId}}"
 				{% else %}
 				value="{{data.widget.id}}"
 				{% endif %}

--- a/packages/cms/lib/modules/arguments-widgets/index.js
+++ b/packages/cms/lib/modules/arguments-widgets/index.js
@@ -97,10 +97,8 @@ module.exports = {
     const superLoad = self.load;
     self.load = async function (req, widgets, next) {
       const promises = widgets.map(async (widget) => {
-        console.log(widget)
         if (widget.ideaId) {
           const resource = await self.apos.openstadApi.getResource(req, req.data.global.siteId, 'idea', widget.ideaId, {includeArguments: 1});
-          console.log(resource);
           widget.ajaxError = null;
           if (resource) {
             widget.activeResource = resource

--- a/packages/cms/lib/modules/arguments-widgets/index.js
+++ b/packages/cms/lib/modules/arguments-widgets/index.js
@@ -81,7 +81,7 @@ module.exports = {
       {
         name: 'advanced',
         label: 'Advanced',
-        fields: ['replyingEnabled', 'votingEnabled', 'showLastNameForArguments', 'showLastNameForReactions', 'ideaId']
+        fields: ['replyingEnabled', 'votingEnabled', 'ideaId']
       }
     ]);
 
@@ -124,17 +124,5 @@ module.exports = {
 
        return superOutput(widget, options);
      };
-
-     self.addHelpers({
-        showLastName: function (type, widget, user) {
-            if (type == 'reactions' && (widget.showLastNameForReactions == 'yes' || (widget.showLastNameForReactions == 'adminonly' && user.role == 'admin'))) {
-                return user.lastName;
-            } else if (type == 'arguments' && (widget.showLastNameForArguments == 'yes' || (widget.showLastNameForArguments == 'adminonly' && user.role == 'admin'))) {
-                return user.lastName;
-            }
-
-            return '';
-        }
-     });
-   },
+   }
 };

--- a/packages/cms/lib/modules/arguments-widgets/index.js
+++ b/packages/cms/lib/modules/arguments-widgets/index.js
@@ -1,23 +1,18 @@
 /**
  * A widget for displaying a list of arguments it's reactions, and a reaction form
- * Needs to be placed on a resource form 
+ * Needs to be placed on a resource form
  */
-const rp = require('request-promise');
-
 module.exports = {
   extend: 'openstad-widgets',
   label: 'Arguments old',
   alias: 'arguments',
   adminOnly: true,
   addFields: [
-  /*
-    Not being used for now,
-    but might in the future
     {
       name: 'ideaId',
       type: 'string',
       label: 'Idea ID (if empty it will try to fetch the ideaId from the URL)',
-    },*/
+    },
     {
       name: 'emptyPlaceholder',
       type: 'string',
@@ -86,13 +81,12 @@ module.exports = {
       {
         name: 'advanced',
         label: 'Advanced',
-        fields: ['replyingEnabled', 'votingEnabled']
+        fields: ['replyingEnabled', 'votingEnabled', 'showLastNameForArguments', 'showLastNameForReactions', 'ideaId']
       }
     ]);
 
 
      const superPushAssets = self.pushAssets;
-     //const auth = "Basic " + new Buffer("xxx:xxx#").toString("base64");
 
      self.pushAssets = function() {
        superPushAssets();
@@ -100,14 +94,49 @@ module.exports = {
        self.pushAsset('stylesheet', 'main', { when: 'always' });
      };
 
+    const superLoad = self.load;
+    self.load = async function (req, widgets, next) {
+      const promises = widgets.map(async (widget) => {
+        console.log(widget)
+        if (widget.ideaId) {
+          const resource = await self.apos.openstadApi.getResource(req, req.data.global.siteId, 'idea', widget.ideaId, {includeArguments: 1});
+          console.log(resource);
+          widget.ajaxError = null;
+          if (resource) {
+            widget.activeResource = resource
+            widget.activeResourceType = 'idea';
+            widget.activeResourceId = resource.id;
+          }
+        }
+      });
+
+      await Promise.all(promises);
+
+      return superLoad(req, widgets, next);
+    }
+
      var superOutput = self.output;
      self.output = function(widget, options) {
-       widget.ideaId =  options.activeResource ?  options.activeResource.id : false;
-       widget.activeResourceType = options.activeResourceType;
-       widget.activeResource = options.activeResource ?  options.activeResource : {};
-       widget.activeResourceId =  options.activeResource ?  options.activeResource.id : false;
+       if(!widget.ideaId || !widget.activeResource) {
+         widget.ideaId = options.activeResource ? options.activeResource.id : false;
+         widget.activeResourceType = options.activeResourceType;
+         widget.activeResource = options.activeResource ? options.activeResource : {};
+         widget.activeResourceId = options.activeResource ? options.activeResource.id : false;
+       }
+
        return superOutput(widget, options);
      };
 
+     self.addHelpers({
+        showLastName: function (type, widget, user) {
+            if (type == 'reactions' && (widget.showLastNameForReactions == 'yes' || (widget.showLastNameForReactions == 'adminonly' && user.role == 'admin'))) {
+                return user.lastName;
+            } else if (type == 'arguments' && (widget.showLastNameForArguments == 'yes' || (widget.showLastNameForArguments == 'adminonly' && user.role == 'admin'))) {
+                return user.lastName;
+            }
+
+            return '';
+        }
+     });
    },
 };

--- a/packages/cms/lib/modules/openstad-api/lib/api.js
+++ b/packages/cms/lib/modules/openstad-api/lib/api.js
@@ -1,5 +1,6 @@
 const request = require('request-promise');
 const queryString = require('query-string');
+const queryString = require('query-string');
 
 module.exports = (self, options) => {
 

--- a/packages/cms/lib/modules/openstad-api/lib/api.js
+++ b/packages/cms/lib/modules/openstad-api/lib/api.js
@@ -1,6 +1,5 @@
 const request = require('request-promise');
 const queryString = require('query-string');
-const queryString = require('query-string');
 
 module.exports = (self, options) => {
 


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description

This allows the argument form (old) and argument (old) widgets to be used on a normal page. You can enter an idea ID which will link the form / arguments to that resource. This allows the editor to create a normal page, where the arguments / argument form can be displayed.

## Type of change

New feature in an existing widget. Has backwards compatibility if the idea ID is not given.

## Tests

Manually

