### PR TITLE
Feat/allow openstad component url to be set in global settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 * Make image size configurable for the image widget
+* Add global setting to set openstad components cdn url
 
 ## 1.0.0
 * Add submission to resource form with configurable confirmation settings

--- a/packages/cms/lib/modules/openstad-components-widgets/index.js
+++ b/packages/cms/lib/modules/openstad-components-widgets/index.js
@@ -44,7 +44,7 @@ module.exports = {
         widget.config = merge.recursive(config, widget.config);
         widget.config = JSON.stringify(config);
 
-        widget.OpenStadComponentsCdn = self.apos.settings.getOption(req, 'siteConfig').openstadComponentsCdn;
+        widget.OpenStadComponentsCdn = (req && req.data && req.data.global && req.data.global.openstadComponentsUrl) || self.apos.settings.getOption(req, 'siteConfig').openstadComponentsCdn;
 
         const containerId = self.apos.utils.generateId();
         widget.containerId = containerId;

--- a/packages/cms/lib/modules/openstad-global/lib/arrangeFields.js
+++ b/packages/cms/lib/modules/openstad-global/lib/arrangeFields.js
@@ -12,7 +12,7 @@ module.exports = [
     {
         name: 'api',
         label: 'Url & api instellingen',
-        fields: ['siteId', 'ideaSlug', 'ideaOverviewSlug', 'editIdeaUrl', 'cacheIdeas']
+        fields: ['siteId', 'ideaSlug', 'ideaOverviewSlug', 'editIdeaUrl', 'cacheIdeas', 'openstadComponentsUrl']
     },
 
     {

--- a/packages/cms/lib/modules/openstad-global/lib/fields.js
+++ b/packages/cms/lib/modules/openstad-global/lib/fields.js
@@ -800,4 +800,12 @@ module.exports = [
         choices: rightsChoices,
         def: 'member'
         },*/
+  
+  {
+    type: 'string',
+    name: 'openstadComponentsUrl',
+    label: 'Openstad Components URL',
+    help: 'Specify the URL where the Openstad Components (choice guide, ideas on map etc.) are loaded from. Leave empty to use the default URL.',
+    def: ''
+  },
 ];


### PR DESCRIPTION
<!-- Please fill in the appropriate information -->

# Description

Adds a global setting to change the openstad components CDN URL. Falls back to the environment set CDN url.

## Type of change

New feature.

## Tests

Manually tested

