### PR TITLE
Fix/broken notification ruleset

### DIFF
--- a/packages/cms/app.js
+++ b/packages/cms/app.js
@@ -43,7 +43,7 @@ let sites = {};
 let sitesById = {};
 let sitesResponse = [];
 const aposStartingUp = {};
-const REFRESH_SITES_INTERVAL =  60000 * 5;
+const REFRESH_SITES_INTERVAL =  60000 * 15;
 
 
 if (process.env.REQUEST_LOGGING === 'ON') {

--- a/packages/cms/lib/modules/resource-form-widgets/lib/api.js
+++ b/packages/cms/lib/modules/resource-form-widgets/lib/api.js
@@ -21,12 +21,19 @@ module.exports = async function(self, options) {
               await self.addOrUpdateNotification(item, 'User');
             } catch (error) {
               console.error(
-                'something went wrong when update admin confirmation settings to api',
+                'something went wrong when update user confirmation settings to api',
                 error.message
               );
             }
           } else {
-            await self.disableNotificationRuleSet(`User-${item.formName}`);
+            try {
+              await self.disableNotificationRuleSet(`User-${item.formName}`);
+            } catch (error) {
+              console.error(
+                'something went wrong when disabling user confirmation settings to api',
+                error.message
+              );
+            }
           }
 
           if (item.confirmationEnabledAdmin) {
@@ -39,7 +46,14 @@ module.exports = async function(self, options) {
               );
             }
           } else {
-            await self.disableNotificationRuleSet(`Admin-${item.formName}`);
+            try {
+              await self.disableNotificationRuleSet(`Admin-${item.formName}`);
+            } catch (error) {
+              console.error(
+                'something went wrong when disabling admin confirmation settings to api',
+                error.message
+              );
+            }
           }
         }
       })


### PR DESCRIPTION
When updating a resource-form where confirmation's are set to "No" an API call is done to disable notifications. When this call fails the frontend would crash. By adding a try catch block this crash is prevented.
