### PR TITLE
Readded actionText, because removing it gives alot of confusion by users

### DIFF
--- a/packages/cms/lib/modules/accordeon-widgets/index.js
+++ b/packages/cms/lib/modules/accordeon-widgets/index.js
@@ -25,7 +25,12 @@ module.exports = {
           label: 'Description',
           widgetType: 'apostrophe-rich-text',
           options: contentWidgets['apostrophe-rich-text'] || {}
-          
+        },
+        {
+          type: 'string',
+          name: 'actionText',
+          label: 'Description (legacy, prefer the rich-text field if possible as this option could be removed in future updates)',
+          textarea: true
         }
       ]
     },


### PR DESCRIPTION
Ondanks dat de actionText veld niet meer gebruikt hoeft te worden. Missen de gebruikers (Simone en mischien andere) dit veld omdat als zij de accordeon openen alleen een leeg textveld zien. Het actionText veld teruggezet zodat ze eenvoudig de teksten kunnen kopieren naar het rich-text veld. Het zou idealer zijn als je twee waardes kon koppelen aan 1 field in index.js. 
