### PR TITLE
Archive repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+> [!WARNING]  
+> This project has been migrated to a new **monorepo** and is no longer maintained here.  
+> Please visit the new repository: [openstad/openstad-headless](https://github.com/openstad/openstad-headless)
+> 
+> More information: [openstad.org](https://openstad.org/)
+
 # An implementation of @openstad/cms for open democracy
 
 ## Prerequisites


### PR DESCRIPTION
This adds an archivation warning before we archive the repository, to point users towards the new headless repository.